### PR TITLE
[fix] fix to the flavor test for work correctly and pass

### DIFF
--- a/test/fixtures/rackspace/flavor.json
+++ b/test/fixtures/rackspace/flavor.json
@@ -1,6 +1,8 @@
 {
+  "flavor": {
     "id": 1,
     "ram": 256,
     "disk": 10,
     "name": "256 server"
+  }
 }


### PR DESCRIPTION
This is a minor fix to the test of compute client of rackspace. In first time we have `assert.assertFlavorDetails` but this test dont check for the details of the flavor, I added more checks to this test in [databases branch](https://github.com/nodejitsu/pkgcloud/tree/databases) and that's how I found this.
