### PR TITLE
[storage] [rackspace] Pass containerName as the path instead of the conatiner instance

### DIFF
--- a/lib/pkgcloud/rackspace/storage/client/files.js
+++ b/lib/pkgcloud/rackspace/storage/client/files.js
@@ -123,7 +123,7 @@ exports.getFiles = function (container, callback) {
   var containerName = container instanceof base.Container ? container.name : container,
       self = this;
 
-  this.request({ path: [container, true] }, callback, function (body, res) {
+  this.request({ path: [containerName, true] }, callback, function (body, res) {
     callback(null, body.map(function (file) {
       file.container = container;
       return new storage.File(self, file);


### PR DESCRIPTION
``` javascript
exports.getFiles = function (container, callback) {
   var containerName = container instanceof base.Container ? container.name : container,
       self = this;

  this.request({ path: [container, true] }, callback, function (body, res) {
```

changed `container` to `containerName` on the last line. This fixes Issue #49.
