### PR TITLE
fixed typo in file.download

### DIFF
--- a/lib/pkgcloud/core/storage/file.js
+++ b/lib/pkgcloud/core/storage/file.js
@@ -1,5 +1,5 @@
 /*
- * file.js: Base container from which all pkgcloud files inherit from 
+ * file.js: Base container from which all pkgcloud files inherit from
  *
  * (C) 2010 Nodejitsu Inc.
  *
@@ -19,19 +19,19 @@ utile.inherits(File, model.Model);
 File.prototype.remove = File.prototype.rm = function (callback) {
   this.client.removeFile(this.containerName, this.name, callback);
 };
-  
+
 File.prototype.download = function (options, callback) {
-  this.client.upload(options, callback);
+  this.client.download(options, callback);
 };
-  
+
 File.prototype.update = function (data, callback) {
-  
+
 };
-  
+
 File.prototype.__defineGetter__('fullPath', function () {
   return this.client.storageUrl(this.containerName, this.name);
 });
-  
+
 File.prototype.__defineGetter__('containerName', function () {
-  return this.container instanceof storage.Container ? this.container.name : this.container; 
+  return this.container instanceof storage.Container ? this.container.name : this.container;
 });


### PR DESCRIPTION
Changed `client.upload` to `client.download`. Fixes Issue #52. 
