### PR TITLE
[fix] Accept `options` in Joyent `.getServers()` to support `limit` and ...

### DIFF
--- a/lib/pkgcloud/joyent/compute/client/servers.js
+++ b/lib/pkgcloud/joyent/compute/client/servers.js
@@ -36,18 +36,33 @@ exports.getLimits = function getLimits(callback) {
 
 //
 // ### function getServers (callback) 
+// #### @options {Object} Options when getting servers
+// ####   @options.offset {number} Number of servers to skip when listing
+// ####   @options.limit  {number} Number of servers to return
 // #### @callback {function} f(err, servers). `servers` is an array that
 // represents the servers that are available to your account
 //
 // Lists all servers available to your account.
 //
-exports.getServers = function getServers(callback) {
+exports.getServers = function getServers(options, callback) {
+  if (!callback && typeof options === 'function') {
+    callback = options;
+    options = {};
+  }
+
   var self = this;
-  return this.request(this.account + '/machines', callback, 
-    function (body, res) { callback(null, body.map(function (result) {
+  return this.request(
+    {
+      path: this.account + '/machines',
+      qs: options
+    },
+    callback,
+    function (body, res) {
+      callback(null, body.map(function (result) {
         return new compute.Server(self, result);
       }), res);
-    });
+    }
+  );
 };
 
 //


### PR DESCRIPTION
...`offset`. Fixes #56
