### PR TITLE
[refactor] Use `node-ip` module to work with IP addresses.

### DIFF
--- a/lib/pkgcloud/core/compute/index.js
+++ b/lib/pkgcloud/core/compute/index.js
@@ -5,6 +5,8 @@
  *
  */
  
+var ip = require('ip');
+
 exports.Bootstrapper = require('./bootstrapper').Bootstrapper;
 exports.Flavor       = require('./flavor').Flavor;
 exports.Image        = require('./image').Image;
@@ -33,13 +35,23 @@ exports.serverIp = function (server) {
   }
 
   var networks,
-      interfaces;
+      interfaces,
+      pub;
 
   if (server.ips) {
     //
-    // Joyent uses the format { ips: ['23.23.23.23', '10.0.0.1'] }
+    // Joyent uses the format:
+    // * { ips: ['23.23.23.23', '10.0.0.1'] }
+    // OR
+    // * { ips: ['10.0.0.1', '23.23.23.23'] }
     //
-    return server.ips[0];
+    pub = server.ips.filter(function (addr) {
+      return ip.isPublic(addr);
+    });
+
+    return !pub.length
+      ? servers.ips[0]
+      : pub[0]
   }
   else if (server.addresses.public || server.addresses.private) {
     //

--- a/lib/pkgcloud/joyent/compute/server.js
+++ b/lib/pkgcloud/joyent/compute/server.js
@@ -5,7 +5,8 @@
  *
  */
 
-var utile = require('utile'),
+var ip = require('ip'),
+    utile = require('utile'),
     base  = require('../../core/compute/server');
 
 var Server = exports.Server = function Server(client, details) {
@@ -36,22 +37,20 @@ Server.prototype._setProperties = function (details) {
     }
   }
 
-  var addresses = {"private": [], "public": []};
-  // calculate ips
-  details.ips.forEach(function (ip) {
-    if(/(^127\.0\.0\.1)|(^10\.)|(^172\.1[6-9]\.)|(^172\.2[0-9]\.)|(^172\.3[0-1]\.)|(^192\.168\.)/.test(ip)) {
-      addresses["private"].push(ip);
+  var addresses = details.ips.reduce(function (all, addr) {
+    if (ip.isPrivate(addr)) {
+      all['private'].push(addr);
     }
     else {
-      addresses["public"].push(ip);
+      all['public'].push(addr);
     }
-  });
 
+    return all;
+  }, { 'private': [], 'public': [] });
 
   //
   // Joyent specific
   //
-  
   this.ips       = details.ips;
   this.imageId   = details.dataset;
   this.addresses = details.addresses = addresses;

--- a/lib/pkgcloud/openstack/compute/server.js
+++ b/lib/pkgcloud/openstack/compute/server.js
@@ -5,7 +5,8 @@
  *
  */
 
-var utile = require('utile'),
+var ip = require('ip'),
+    utile = require('utile'),
     base = require('../../core/compute/server');
 
 var Server = exports.Server = function Server(client, details) {
@@ -77,13 +78,10 @@ Server.prototype._setProperties = function (details) {
         Object.keys(interfaces).map(function (interface) {
           return interfaces[interface].addr
         })
-        .forEach(function (ip) {
-          if (/(^127\.0\.0\.1)|(^10\.)|(^172\.1[6-9]\.)|(^172\.2[0-9]\.)|(^172\.3[0-1]\.)|(^100\.)/.test(ip)) {
-            all['private'].push(ip);
-          }
-          else {
-            all['public'].push(ip);
-          }
+        .forEach(function (addr) {
+          return ip.isPrivate(addr)
+            ? all['private'].push(addr)
+            : all['public'].push(addr);
         });
 
         return all;

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "errs":          "0.2.x",
     "eventemitter2": "0.4.x",
     "filed":         "0.0.7",
+    "ip":            "0.0.x",
     "xml2js":        "0.1.x",
     "mime":          "1.2.x",
     "morestreams":   "0.1.x",


### PR DESCRIPTION
Makes working with private IPs much easier.
