### PR TITLE
[refactor] Poll SSH instead of fixed timeout while bootstrapping

### DIFF
--- a/lib/pkgcloud/core/compute/bootstrapper.js
+++ b/lib/pkgcloud/core/compute/bootstrapper.js
@@ -211,13 +211,17 @@ Bootstrapper.prototype.createServer = function (options) {
         //
         // Grace period for IP propagation
         //
-        setTimeout(function () {
+        self._sshPoll(options, function (err) {
+          if (err) {
+            return onError(err);
+          }
+
           self.bootstrapServer(options)
             .on('error', onError)
             .on('complete', function () {
               emitter.emit('complete', server);
             });
-        }, 60 * 1000);
+        });
       }
 
       return options.afterCreate
@@ -761,4 +765,44 @@ Bootstrapper.prototype._exec = function (command, options) {
   });
 
   return emitter;
+};
+
+//
+// ### @private function _sshPoll (options)
+// #### @options {Object} Options to use when polling the server.
+// #### @callback {function} Continuation to respond to.
+// Polls server over ssh, trying to determine when server is actually up and
+// active, ready to accept commands.
+//
+Bootstrapper.prototype._sshPoll = function (options, callback) {
+  // TODO (mmalecki): make maxTries and interval configurable
+  var self = this,
+      maxTries = 10,
+      interval = 30 * 1000,
+      tries = 0;
+
+  function poll() {
+    var child = self.ssh({
+      keys: options.keys,
+      server: options.server,
+      tunnel: options.tunnel,
+      remoteUser: options.remoteUser,
+      commands: ['true']
+    });
+
+    child.on('error', function () {
+      ++tries;
+      if (tries === maxTries) {
+        return callback(new Error('Server didn\'t become active in timely fashion'));
+      }
+
+      setTimeout(poll, interval);
+    });
+
+    child.on('complete', function () {
+      return callback();
+    });
+  }
+
+  poll();
 };


### PR DESCRIPTION
Various compute providers need different time to bring the VM up and
make it accessible under some IP. Previously we'd simply wait a minute
before trying to bootstrap the server.
This polls VM over SSH to determine when it's up and ready to accept
commands.
