### PR TITLE
Fix exit code for npm tests

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -60,4 +60,7 @@ vows.stderr.on('data', function (data) {
 
 vows.on('exit', function (code) {
   console.log('vows exited with code ' + code);
+
+  // propagate our exit code through for travis-ci
+  process.exit(code);
 });


### PR DESCRIPTION
Currently, we don't propagate the vows exit code back to the npm process. This means all tests "pass" as travis and npm test look at the process exit code, which will always be 0.
