### PR TITLE
[api refactor] Expose methods for determining if an IP address is public...

### DIFF
--- a/lib/pkgcloud/core/compute/index.js
+++ b/lib/pkgcloud/core/compute/index.js
@@ -12,6 +12,24 @@ exports.Flavor       = require('./flavor').Flavor;
 exports.Image        = require('./image').Image;
 exports.Server       = require('./server').Server;
 
+//
+// ### function isPrivate (addr)
+// Determines if an IP address is private.
+//
+exports.isPrivate = ip.isPrivate;
+
+//
+// ### function isPublic (addr)
+// Determines if an IP address is public.
+//
+exports.isPublic = ip.isPublic;
+
+//
+// ### function serverPass (server)
+// #### @server {Object} Server to extract the serverPass from.
+//
+// Returns the server password (if it exists).
+//
 exports.serverPass = function (server) {
   if (server.adminPass) {
     return server.adminPass;
@@ -34,8 +52,9 @@ exports.serverIp = function (server) {
     return null;
   }
 
-  var networks,
-      interfaces,
+  var interfaces,
+      addresses,
+      networks,
       pub;
 
   if (server.ips) {
@@ -46,7 +65,7 @@ exports.serverIp = function (server) {
     // * { ips: ['10.0.0.1', '23.23.23.23'] }
     //
     pub = server.ips.filter(function (addr) {
-      return ip.isPublic(addr);
+      return exports.isPublic(addr);
     });
 
     return !pub.length
@@ -84,15 +103,31 @@ exports.serverIp = function (server) {
     //   ]
     // }
     //
-    networks = Object.keys(server.addresses);
-    if (!networks.length) {
+    interfaces = Object.keys(server.addresses);
+    if (!interfaces.length) {
       return null;
     }
 
-    interfaces = server.addresses[networks[0]];
+    addresses = interfaces.reduce(function (all, iface) {
+      server.addresses[iface]
+        .map(function (info) { return info.addr })
+        .filter(Boolean)
+        .forEach(function (addr) {
+          if (exports.isPublic(addr)) {
+            all['public'].push(addr);
+          }
+          else if (exports.isPrivate(addr)) {
+            all['private'].push(addr);
+          }
+        });
 
-    return (interfaces[1] && interfaces[1].addr)
-      || (interfaces[0] && interfaces[0].addr)
+      return all;
+    }, { public: [], private: [] });
+
+    return addresses['public'][0]
+      || addresses['private'][0]
       || null;
   }
+
+  return null;
 };

--- a/lib/pkgcloud/joyent/compute/server.js
+++ b/lib/pkgcloud/joyent/compute/server.js
@@ -5,9 +5,9 @@
  *
  */
 
-var ip = require('ip'),
-    utile = require('utile'),
-    base  = require('../../core/compute/server');
+var utile   = require('utile'),
+    compute = require('../../core/compute'),
+    base    = require('../../core/compute/server');
 
 var Server = exports.Server = function Server(client, details) {
   base.Server.call(this, client, details);
@@ -38,7 +38,7 @@ Server.prototype._setProperties = function (details) {
   }
 
   var addresses = details.ips.reduce(function (all, addr) {
-    if (ip.isPrivate(addr)) {
+    if (compute.isPrivate(addr)) {
       all['private'].push(addr);
     }
     else {

--- a/lib/pkgcloud/openstack/compute/server.js
+++ b/lib/pkgcloud/openstack/compute/server.js
@@ -5,9 +5,9 @@
  *
  */
 
-var ip = require('ip'),
-    utile = require('utile'),
-    base = require('../../core/compute/server');
+var utile   = require('utile'),
+    compute = require('../../core/compute'),
+    base    = require('../../core/compute/server');
 
 var Server = exports.Server = function Server(client, details) {
   base.Server.call(this, client, details);
@@ -79,7 +79,7 @@ Server.prototype._setProperties = function (details) {
           return interfaces[interface].addr
         })
         .forEach(function (addr) {
-          return ip.isPrivate(addr)
+          return compute.isPrivate(addr)
             ? all['private'].push(addr)
             : all['public'].push(addr);
         });


### PR DESCRIPTION
... or private.

This will be useful for anyone using a [netmask](http://www.computerhope.com/jargon/n/netmask.htm) to determine if an IP is public or private on their network.

e.g.

``` js
var pkgcloud = require('pkgcloud'),
    Netmask = require('netmask').Netmask;

var masks = {
  public: new Netmask('100.127/16'),
  private: new Netmask('1.127/16')
};

//
// Override isPublic and isPrivate to
// conform to the netmask.
//
pkgcloud.compute.isPrivate = function (addr) {
  return masks.private.contains(addr);
};

pkgcloud.compute.isPublic = function (addr) {
  return masks.public.contains(addr);
};
```
