### PR TITLE
Fix Rackspace getFiles Parameters

### DIFF
--- a/lib/pkgcloud/rackspace/storage/file.js
+++ b/lib/pkgcloud/rackspace/storage/file.js
@@ -62,11 +62,11 @@ File.prototype._setProperties = function (details) {
   this.container = details.container || null;
   this.name = details.name || null;
   this.etag = details.hash || details.etag || null;
-  this.contentType = details['content_type'] || details['content-type'] || null;
+  this.contentType = details['contentType'] || details['content_type'] || details['content-type'] || null;
 
 
-  this.lastModified = (details['last_modified'] || details['last-modified'])
-    ? new Date(details['last_modified'] || details['last-modified'])
+  this.lastModified = (details['lastModified'] || details['last_modified'] || details['last-modified'])
+    ? new Date(details['lastModified'] || details['last_modified'] || details['last-modified'])
     : null;
 
   this.size = this.bytes = details['bytes'] || details['content-length']


### PR DESCRIPTION
Rackspace returns different details with underscore, not with minus
`content_type` `content-type`

Example at issue https://github.com/nodejitsu/pkgcloud/issues/105

I dont now if this was a change in rackspace api (use it since a short time), so i leave `content-type` and the other changed fields as fallback in code.
