### PR TITLE
Adding a fix for the signing path on AWS S3

### DIFF
--- a/lib/pkgcloud/amazon/storage/client/containers.js
+++ b/lib/pkgcloud/amazon/storage/client/containers.js
@@ -19,7 +19,9 @@ var async = require('async'),
 exports.getContainers = function (callback) {
   var self = this;
 
-  this.xmlRequest(function (err, body) {
+  this.xmlRequest({
+    path: '/'
+  }, function (err, body) {
     if (err) {
       return callback(err);
     }

--- a/lib/pkgcloud/common/aws-signature.js
+++ b/lib/pkgcloud/common/aws-signature.js
@@ -105,8 +105,12 @@ exports.signHeaders = function signHeaders(req, options) {
     }
   });
 
-  signatureString.push('/' + req.path);
-  if (req.path && req.path !== '') signatureString.push('/');
+  if (req.signingUrl) {
+    signatureString.push(req.signingUrl);
+  }
+  else {
+    signatureString.push(req.path);
+  }
 
   var signature = crypto.createHmac(
       'sha1',

--- a/lib/pkgcloud/core/base/client.js
+++ b/lib/pkgcloud/core/base/client.js
@@ -69,6 +69,15 @@ Client.prototype._doRequest = function (options, callback) {
     requestOptions.body = options.body;
   }
 
+  if (options.container) {
+    requestOptions.signingUrl = '/' + options.container + '/';
+
+    if (options.path) {
+      requestOptions.signingUrl += options.path;
+    }
+  }
+
+
   function sendRequest(opts) {
 
     //
@@ -97,7 +106,13 @@ Client.prototype._doRequest = function (options, callback) {
 
 //    console.log((opts.method ? opts.method : 'GET') + ': ' + opts.uri + (opts.qs ? '?' + qs.encode(opts.qs) : ''));
 
+    // Clean up our polluted options
+    //
+    // TODO refactor the options used in Before methods
+    // to not require polluting request options
+    //
     delete opts.path;
+    delete opts.signingUrl;
 
     // If we are missing either the errback or callback
     if (!callback) {


### PR DESCRIPTION
This fixes #121.

Currently, the before methods on a client take the official request `options` and amend them as appropriate. I want to rethink this approach going forward with the idea of a wrapper object that has input options that may not be part of the official **request** options, thus allowing a model where you don't have to pollute/cleanup on the official request object.
