### PR TITLE
[storage] remove good case handling from aws

### DIFF
--- a/lib/pkgcloud/amazon/storage/client/files.js
+++ b/lib/pkgcloud/amazon/storage/client/files.js
@@ -119,17 +119,22 @@ exports.multipartUpload = function (options, callback) {
 
   // Wait for first data event, probably file is less than 5 mbs and
   // we don't need that multipart thing at all
+  var first = null,
+      fastCase = true;
+
   stream.once('data', function (data) {
     // Good case - all data fits in one chunk
-    if (data.length < chunk) {
-      options.headers['content-length'] = data.length;
+    if (fastCase) {
+      if (data.length < chunk && !first) {
+        first = data;
+        return;
+      } else {
+        fastCase = false;
 
-      // Upload with default method once again
-      var rstream = self.upload(options, handleResponse);
-      rstream.write(data);
-      rstream.end();
-
-      return;
+        // Emit accumulated chunk
+        self.emit('data', first);
+        first = null;
+      }
     }
 
     stream.pause();
@@ -166,6 +171,18 @@ exports.multipartUpload = function (options, callback) {
   });
 
   stream.on('end', function () {
+    if (fastCase) {
+      // Upload with default method once again
+      var rstream = self.upload(utile.mixin({}, options, {
+        stream: null,
+        headers: utile.mixin({}, options.headers, {
+          'content-length': first.length
+        })
+      }), handleResponse);
+      rstream.end(first);
+      return;
+    }
+
     ended = true;
     finish();
   });


### PR DESCRIPTION
The way this good case is handled is simply incorrect, because it should
wait for `end` event to figure out that this chunk is the last. However,
complexity of implementing this logic is much higher, than the profit
that it might give to anyone.

/cc @kenperkins
