### PR TITLE
[streams] Allow streams to be piped without callbacks

### DIFF
--- a/lib/pkgcloud/amazon/storage/client/files.js
+++ b/lib/pkgcloud/amazon/storage/client/files.js
@@ -90,8 +90,8 @@ exports.upload = function (options, callback) {
       headers: options.headers || {}
     }, function (err, body, res) {
       return err
-        ? callback(err)
-        : callback(null, res.statusCode == 200, res);
+        ? callback && callback(err)
+        : callback && callback(null, res.statusCode == 200, res);
     });
   } else {
     // Multi-part, 5mb chunk upload
@@ -123,7 +123,7 @@ exports.multipartUpload = function (options, callback) {
   function handleResponse(err, body, res) {
     if (handleResponse.called) return;
     handleResponse.called = true;
-    callback(err, body, res);
+    callback && callback(err, body, res);
   }
 
   handleResponse.called = false;
@@ -302,8 +302,8 @@ exports.download = function (options, callback) {
     download: true
   }, function (err, body, res) {
     return err
-      ? callback(err)
-      : callback(null, new (storage.File)(self, utile.mixin(res.headers, {
+      ? callback && callback(err)
+      : callback && callback(null, new (storage.File)(self, utile.mixin(res.headers, {
         container: container,
         name: options.remote
       })));

--- a/lib/pkgcloud/azure/storage/client/files.js
+++ b/lib/pkgcloud/azure/storage/client/files.js
@@ -92,8 +92,8 @@ exports.upload = function (options, callback) {
       qs: options.qs
     }, function (err, body, res) {
       return err
-        ? callback(err)
-        : callback(null, res.statusCode === 200 || res.statusCode === 201, res);
+        ? callback && callback(err)
+        : callback && callback(null, res.statusCode === 200 || res.statusCode === 201, res);
     });
   } else {
     // Multi-part, 5mb chunk upload
@@ -195,8 +195,8 @@ exports.sendBlockList = function (options, numBlocks, callback) {
     qs: qs
   }, function (err, body, res) {
     return err
-      ? callback(err)
-      : callback(null, res.statusCode === 201, res);
+      ? callback && callback(err)
+      : callback && callback(null, res.statusCode === 201, res);
   });
 };
 
@@ -222,8 +222,8 @@ exports.download = function (options, callback) {
     download: true
   }, function (err, body, res) {
     return err
-      ? callback(err)
-      : callback(null, new (storage.File)(self, utile.mixin(res.headers, {
+      ? callback && callback(err)
+      : callback && callback(null, new (storage.File)(self, utile.mixin(res.headers, {
           container: container,
           name: options.remote
         })));

--- a/lib/pkgcloud/core/base/client.js
+++ b/lib/pkgcloud/core/base/client.js
@@ -122,7 +122,7 @@ Client.prototype._doRequest = function (options, callback) {
     // Set our User Agent
     opts.headers['User-Agent'] = utile.format('nodejs-pkgcloud/%s', pkgcloud.version);
 
-    // If we are missing either the errback or callback
+    // If we are missing callback
     if (!callback) {
       try {
         return request(opts);

--- a/lib/pkgcloud/rackspace/storage/client/files.js
+++ b/lib/pkgcloud/rackspace/storage/client/files.js
@@ -84,8 +84,8 @@ exports.upload = function (options, callback) {
     headers: options.headers || {}
   }, function (err, body, res) {
     return err
-      ? callback(err)
-      : callback(null, true, res);
+      ? callback && callback(err)
+      : callback && callback(null, true, res);
   });
 
   if (inputStream) {
@@ -117,8 +117,8 @@ exports.download = function (options, callback) {
     download: true
   }, function (err, body, res) {
     return err
-      ? callback(err)
-      : callback(null, new (storage.File)(self, utile.mixin(res.headers, {
+      ? callback && callback(err)
+      : callback && callback(null, new (storage.File)(self, utile.mixin(res.headers, {
           container: container,
           name: options.remote
         })));


### PR DESCRIPTION
There was a case where if you piped between two streams with `pkgcloud` and you didn't provide a download callback, it would crash because it was trying to invoke an undefined.

For example, streaming between two storage clients would crash:

``` Javascript
client.download({ ... }).pipe(client2.upload({ ... }, function(err, result));
```

This fixes #138.
