### PR TITLE
Allow for marker param on RackSpace CloudFiles

### DIFF
--- a/lib/pkgcloud/rackspace/storage/client/files.js
+++ b/lib/pkgcloud/rackspace/storage/client/files.js
@@ -154,17 +154,20 @@ exports.getFile = function (container, file, callback) {
 exports.getFiles = function (container, download, callback) {
   var containerName = container instanceof base.Container ? container.name : container,
       self = this;
-
+ 
+  var qs = {}
+  if (typeof download == 'object') {
+    qs = download;
+  }
   if (typeof download == 'function' && !(download instanceof RegExp)) {
     callback = download;
     download = false;
   }
+  qs.format = 'json'
 
   this.request({
     path: containerName,
-    qs: {
-      format: 'json'
-    }
+    qs: qs
   }, function (err, body, res) {
     return err
       ? callback(err)


### PR DESCRIPTION
issue #147

CloudFiles api limits getFiles to 10k files, so you need a marker param to be able to designate a file offset.

I overrode the download parameter to allow for an object of query parameters.  I haven't looked through the rest of pkgcloud so I'm not sure if there's a better standard to follow or if any of the other storage APIs require similar functionality.  I'm open to other implementations if something else makes sense.
