### PR TITLE
Add Status SHUTOFF case to OpenStack provider

### DIFF
--- a/lib/pkgcloud/openstack/compute/server.js
+++ b/lib/pkgcloud/openstack/compute/server.js
@@ -31,6 +31,7 @@ Server.prototype._setProperties = function (details) {
         this.status = "RUNNING";
         break;
       case 'SUSPENDED':
+      case 'SHUTOFF':
         this.status = "STOPPED";
         break;
       case 'REBOOT':


### PR DESCRIPTION
Rackspace (and Openstack) both report Status: 'SHUTOFF' when the guest operating system is shutdown.  This state is currently reported as 'UNKNOWN' in pkgcloud.

I've simply added an additional case to the switch statement to translate SHUTOFF (along with SUSPENDED) to 'STOPPED'.
