### PR TITLE
Remove reference to nonexistent this.progress

### DIFF
--- a/lib/pkgcloud/openstack/compute/server.js
+++ b/lib/pkgcloud/openstack/compute/server.js
@@ -59,7 +59,7 @@ Server.prototype._setProperties = function (details) {
   //
   // Set extra properties
   //
-  this.progress  = details.progress  || this.progress;
+  this.progress  = details.progress;
   this.imageId   = details.imageId   || this.imageId;
   this.adminPass = details.adminPass || this.adminPass;
   this.addresses = details.addresses || {};


### PR DESCRIPTION
In Rackspace and/or Openstack, when an instance is rebooted, progress is reset to 0.

Pkgcloud reports the progress as 'undefined' due to this minor issue that I've fixed.
