### PR TITLE
[Openstack] Add ERROR case for Server status.

### DIFF
--- a/lib/pkgcloud/openstack/compute/server.js
+++ b/lib/pkgcloud/openstack/compute/server.js
@@ -49,6 +49,7 @@ Server.prototype._setProperties = function (details) {
         this.status = "UPDATING";
         break;
       case 'RESCUE':
+      case 'ERROR':
         this.status = 'ERROR';
         break;
       default:


### PR DESCRIPTION
Just adding another missing status case ('ERROR') for Openstack/Rackspace providers.
