### PR TITLE
[test] Add Code Coverage for pkgcloud

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ test/configs/*.json
 !test/configs/providers.json
 .idea
 azure_error
+coverage.html
+.coveralls.yml
+pkgcloud.lcov*

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,10 @@ notifications:
   email:
     - travis@nodejitsu.com
   irc: "irc.freenode.org#nodejitsu"
+
+before_script:
+  - git clone git://github.com/visionmedia/node-jscoverage.git
+  - pushd node-jscoverage
+  - ./configure
+  - make
+  - popd

--- a/Makefile
+++ b/Makefile
@@ -10,4 +10,25 @@ test-unit:
 	    --reporter $(REPORTER) \
 		$(MOCHA_OPTS)
 
+lib-cov:
+	jscoverage --encoding=UTF-8 lib lib-cov
+
+test-cov:	lib-cov
+	mv lib lib-bak
+	mv lib-cov lib
+	$(MAKE) test REPORTER=html-cov > coverage.html
+	rm -rf lib
+	mv lib-bak lib
+
+test-coveralls:	lib-cov
+	echo TRAVIS_JOB_ID $(TRAVIS_JOB_ID)
+	mv lib lib-bak
+	mv lib-cov lib
+	$(MAKE) test REPORTER=mocha-lcov-reporter > pkgcloud.lcov.raw
+	sed "s#SF:#SF:$(PWD)/lib/#g" pkgcloud.lcov.raw > pkgcloud.lcov
+	./node_modules/coveralls/bin/coveralls.js < pkgcloud.lcov
+	rm pkgcloud.lcov pkgcloud.lcov.raw
+	rm -rf lib
+	mv lib-bak lib
+
 .PHONY: test

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ pkgcloud is a standard library for node.js that abstracts away differences among
 * _Fine Print_
   * [Installation](#installation)
   * [Tests](#tests)
+  * [Code Coverage](#coverage)
   * [Contribute!](#contributing)
   * [Roadmap](#roadmap)
 
@@ -321,6 +322,36 @@ Windows - Mocha installed locally:
 ```
 
 
+<a name="coverage"></a>
+## Code Coverage
+You will need jscoverage installed in order to run code coverage.  There seems to be many forks of the jscoverage project, but the recommended one is [node-jscoverage](https://github.com/visionmedia/node-jscoverage), because we use [node-coveralls](https://github.com/cainus/node-coveralls) to report coverage to http://coveralls.io.  node-coveralls requires output from [mocha-lcov-reporter](https://github.com/StevenLooman/mocha-lcov-reporter), whose documentation mentions node-jscoverage.
+
+### Warning
+
+**Running coverage will mess with your lib folder.  It will make a backup lib-bak before running and restore it if the coverage task runs successfully.**
+
+In order to simplify cleanup if something goes wrong, it is recommended to have all all new files added and all changes committed before running coverage, so you'll be able to restore with these commands if something goes wrong:
+
+``` bash
+git clean -fd
+git checkout lib
+```
+
+### Coverage Pre-requisites
+
+Please make sure jscoverage has been installed following the instructions at [node-jscoverage](https://github.com/visionmedia/node-jscoverage).
+
+### Local Coverage
+
+<code>make test-cov</code>
+
+### Run Coverage locally and send to coveralls.io
+
+Travis takes care of coveralls, so this shouldn't be necessary unless you're troubleshooting a problem with Travis/Coveralls.
+You'll need to have access to the coveralls repo_token, which should only be visible to nodejitsu/pkgcloud admins.
+
+1. Create a .coveralls.yml containing the repo_token from https://coveralls.io/r/nodejitsu/pkgcloud
+2. Run <code>make test-coveralls</code>
 
 <a name="contributing"></a>
 ## Contribute!

--- a/lib/pkgcloud/azure/utils/sharedkeytable.js
+++ b/lib/pkgcloud/azure/utils/sharedkeytable.js
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * Copyright (c) Microsoft.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/pkgcloud/core/compute/bootstrapper.js
+++ b/lib/pkgcloud/core/compute/bootstrapper.js
@@ -783,7 +783,7 @@ Bootstrapper.prototype._exec = function (command, options) {
 //
 Bootstrapper.prototype._sshPoll = function (options, callback) {
   var interval   = options.pollInterval || 30 * 1000,
-      maxRetries = options.pollMax      || 10,
+      maxRetries = options.pollMax      || 10,
       attempts   = 0,
       self = this;
 

--- a/package.json
+++ b/package.json
@@ -44,9 +44,15 @@
   "devDependencies": {
     "hock" : "0.2.x",
     "mocha": "1.9.x",
-    "should": "1.2.x"
+    "should": "1.2.x",
+    "mocha-lcov-reporter": "0.0.1",
+    "coveralls": "2.x.x"
   },
   "main":    "./lib/pkgcloud",
-  "scripts": { "test": "make test" },
+  "scripts": {
+    "test": "make test",
+    "test-cov": "make test-cov",
+    "test-coveralls": "make test-coveralls"
+  },
   "engines": { "node": "0.8.x || 0.10.x" }
 }


### PR DESCRIPTION
Adds code coverage report.  Can run with either <code>make test-cov</code> or <code>npm run-script test-cov</code>.

Note: the usual way to setup coverage seems to be to modify all your require statements so they can load from either lib or lib-cov, based on an environment variable.  I took the approach of temporarily replacing lib with lib-cov.  That's fewer changes, but can potentially leave your lib folder in a bad state.  That only happens if you run coverage (which is not on by default for npm test), and can be fixed by restoring from lib-bak or via git checkout and git clean.

Coveralls _should_ work as well via test-coveralls, but it is looking for files in the wrong path.  I think it may be a node-coveralls bug.  Coveralls is the goal, because then it will tell whether Pull Requests increase or decrease coverage.  I'm not a fan of explicit coverage targets, but I like this tool for [finding untested code](http://martinfowler.com/bliki/TestCoverage.html).
