### PR TITLE
Added getTenantInfo function to Openstack Identity

### DIFF
--- a/lib/pkgcloud/openstack/identity/identity.js
+++ b/lib/pkgcloud/openstack/identity/identity.js
@@ -312,3 +312,60 @@ Identity.prototype.validateToken = function(token, belongsTo, callback) {
     });
   }
 };
+
+
+/**
+ *  Identity.getTenantInfo
+ *
+ *  This is an administrative API that allows a admin to get detailed information about the specified tenant by ID
+ *
+ *  @param {String|Function}  [tenantId]  The tenantId for which we are seeking info
+ *  @param callback
+ *
+ */
+Identity.prototype.getTenantInfo = function(tenantId, callback) {
+
+  var self = this;
+
+  if (typeof tenantId === 'function' && !callback) {
+    callback = tenantId;
+    tenantId = null;
+  }
+
+ if (self.token) {
+     tenantInfo();
+   }
+   else {
+     self.authorize(function(err) {
+       if (err) {
+         return callback(err);
+       }
+
+       tenantInfo();
+     });
+   }
+
+   function tenantInfo() {
+
+    var url = self.options.adminAuthUrl
+      ? urlJoin(self.options.adminAuthUrl, '/v2.0')
+      : self.serviceCatalog.getServiceByType('identity').getEndpointUrl({ admin: true });
+
+    var options = {
+      uri: urlJoin(url, '/tenants', tenantId ? tenantId : ''),
+      method: 'GET',
+      headers: {
+        'X-Auth-Token': self.token.id,
+        'User-Agent': util.format('nodejs-pkgcloud/%s', pkgcloud.version)
+      }
+    };
+
+    request(options, function(err, res, body) {
+      return err
+        ? callback(err)
+        : (res.statusCode === 200
+            ? callback(err, body)
+            : callback(err));
+    });
+  }
+};


### PR DESCRIPTION
This function will give administrative option to get the tenant Info for a specified
tenantId. If no tenantId is specified it will return the tenant info of
the tenant to whom the auth token used belongs. Corresponding tests were
also added.

http://docs.openstack.org/api/openstack-identity-service/2.0/content/Tenant_Operations.html
