### PR TITLE
Better handling of empty responses from Rackspace

### DIFF
--- a/lib/pkgcloud/openstack/compute/client/flavors.js
+++ b/lib/pkgcloud/openstack/compute/client/flavors.js
@@ -21,11 +21,17 @@ exports.getFlavors = function getFlavors(callback) {
   return this.request({
     path: 'flavors/detail'
   }, function (err, body, res) {
-    return err
-      ? callback(err)
-      : callback(null, body.flavors.map(function (result) {
-          return new compute.Flavor(self, result);
-        }), res);
+    if (err) {
+      return callback(err);
+    }
+    if (!body || !body.flavors) {
+      return callback(new Error('Unexpected empty response'));
+    }
+    else {
+      return callback(null, body.flavors.map(function (result) {
+        return new compute.Flavor(self, result);
+      }), res);
+    }
   });
 };
 
@@ -44,8 +50,14 @@ exports.getFlavor = function getFlavor(flavor, callback) {
   return this.request({
     path: 'flavors/' + flavorId
   }, function (err, body, res) {
-    return err
-      ? callback(err)
-      : callback(null, new compute.Flavor(self, body.flavor), res);
+    if (err) {
+      return callback(err);
+    }
+    if (!body || !body.flavors) {
+      return callback(new Error('Unexpected empty response'));
+    }
+    else {
+      return callback(null, new compute.Flavor(self, body.flavor), res);
+    }
   });
 };

--- a/lib/pkgcloud/openstack/compute/client/images.js
+++ b/lib/pkgcloud/openstack/compute/client/images.js
@@ -28,11 +28,17 @@ exports.getImages = function getImages(callback) {
   return this.request({
     path: 'images/detail'
   }, function (err, body, res) {
-    return err
-      ? callback(err)
-      : callback(null, body.images.map(function (result) {
-          return new compute.Image(self, result);
-        }), res);
+    if (err) {
+      return callback(err);
+    }
+    if (!body || ! body.images) {
+      return callback(new Error('Unexpected empty response'));
+    }
+    else {
+      return callback(null, body.images.map(function (result) {
+        return new compute.Image(self, result);
+      }), res);
+    }
   });
 };
 
@@ -51,9 +57,15 @@ exports.getImage = function getImage(image, callback) {
   return this.request({
     path: 'images/' + imageId
   }, function (err, body, res) {
-    return err
-      ? callback(err)
-      : callback(null, new compute.Image(self, body.image), res);
+    if (err) {
+      return callback(err);
+    }
+    if (!body || !body.image) {
+      return callback(new Error('Unexpected empty response'));
+    }
+    else {
+      return callback(null, new compute.Image(self, body.image), res);
+    }
   });
 };
 

--- a/lib/pkgcloud/openstack/compute/client/servers.js
+++ b/lib/pkgcloud/openstack/compute/client/servers.js
@@ -56,11 +56,17 @@ exports.getServers = function getServers(callback) {
   return this.request({
     path: 'servers/detail'
   }, function (err, body, res) {
-    return err
-      ? callback(err)
-      : callback(null, body.servers.map(function (result) {
-          return new compute.Server(self, result);
-        }), res);
+    if (err) {
+      return callback(err);
+    }
+    if (!body || !body.servers) {
+      return callback(new Error('Unexpected empty response'));
+    }
+    else {
+      return callback(null, body.servers.map(function (result) {
+        return new compute.Server(self, result);
+      }), res);
+    }
   });
 };
 
@@ -179,9 +185,15 @@ exports.getServer = function getServer(server, callback) {
   return this.request({
     path: 'servers/' + serverId
   }, function (err, body, res) {
-    return err
-      ? callback(err)
-      : callback(null, new compute.Server(self, body.server), res);
+    if (err) {
+      return callback(err);
+    }
+    if (!body.server) {
+      return new Error('Unexpected empty response');
+    }
+    else {
+      callback(null, new compute.Server(self, body.server), res);
+    }
   });
 };
 


### PR DESCRIPTION
We occasionally see empty responses (or perhaps empty body objects) from Rackspace -- especially for getFlavors and getImages (which we call pretty regularly) but the err object is null.  Currently, this causes an uncaught exception in most of these functions because they don't handle this error.

I went through and updated most of the OpenStack 'get' functionality to properly handle this odd error condition.

Full disclosure: 
- npm test passes, but I didn't implement test cases for the error conditions
- I've tested this branch on our app in development
- We haven't tested this branch in staging or production (yet)
