### PR TITLE
Fix wrong uri (without host) for rackspace.dns.updateRecords

### DIFF
--- a/lib/pkgcloud/rackspace/dns/client/records.js
+++ b/lib/pkgcloud/rackspace/dns/client/records.js
@@ -132,9 +132,9 @@ module.exports = {
     self._asyncRequest(requestOptions, function(err, result) {
       return err
         ? callback(err)
-        : callback(null, result.response.records.map(function (record) {
+        : callback(null, result.response ? result.response.records.map(function (record) {
         return new dns.Record(self, record);
-      }));
+      }) : []);
     });
   },
 


### PR DESCRIPTION
Rackspace DNS updateRecord method isn't functional. Only build part of url (like "domains/XXXX/records"), omitting host. This seems to be a simple typo. Fixing it.
