### PR TITLE
Fix error creating server with invalid image

### DIFF
--- a/lib/pkgcloud/openstack/compute/client/servers.js
+++ b/lib/pkgcloud/openstack/compute/client/servers.js
@@ -139,7 +139,7 @@ exports.createServer = function createServer(options, callback) {
       return callback(err);
     }
 
-    if (!body.server) {
+    if (!body || !body.server) {
       return new Error('Server not passed back from OpenStack.');
     }
 


### PR DESCRIPTION
While working on multi-pkgcloud, I noticed that Rackspace createServer doesn't handle invalid image IDs.  Rather than responding with an error, it simply responds with nothing!

In pkgcloud, we see this:

```
TypeError: Cannot read property 'server' of undefined
    at /Users/rossk/dev/opensource/multi-pkgcloud/node_modules/pkgcloud/lib/pkgcloud/openstack/compute/client/servers.js:133:14
    at Request._callback (/Users/rossk/dev/opensource/multi-pkgcloud/node_modules/pkgcloud/lib/pkgcloud/core/base/client.js:166:14)
    at Request.self.callback (/Users/rossk/dev/opensource/multi-pkgcloud/node_modules/pkgcloud/node_modules/request/index.js:148:22)
    at Request.EventEmitter.emit (events.js:98:17)
    at Request.<anonymous> (/Users/rossk/dev/opensource/multi-pkgcloud/node_modules/pkgcloud/node_modules/request/index.js:886:14)
    at Request.EventEmitter.emit (events.js:117:20)
    at IncomingMessage.<anonymous> (/Users/rossk/dev/opensource/multi-pkgcloud/node_modules/pkgcloud/node_modules/request/index.js:837:12)
    at IncomingMessage.EventEmitter.emit (events.js:117:20)
    at _stream_readable.js:920:16
    at process._tickCallback (node.js:415:13)
```

This handles this odd case.
