### PR TITLE
coveralls report fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,10 +25,10 @@ test-coveralls:	lib-cov
 	mv lib lib-bak
 	mv lib-cov lib
 	$(MAKE) test REPORTER=mocha-lcov-reporter > pkgcloud.lcov.raw
+	rm -rf lib
+	mv lib-bak lib
 	sed "s#SF:#SF:$(PWD)/lib/#g" pkgcloud.lcov.raw > pkgcloud.lcov
 	./node_modules/coveralls/bin/coveralls.js < pkgcloud.lcov
 	rm pkgcloud.lcov pkgcloud.lcov.raw
-	rm -rf lib
-	mv lib-bak lib
 
 .PHONY: test


### PR DESCRIPTION
This fixes the coveralls support originally added in #162.  If you publish results to coveralls, it was showing the wrong source: instrumented files instead of the original js.

I see @indexzero mentioned blanket as an alternative, so maybe someone can give that a shot instead of merging this.

Either way, if you want Coveralls's GitHub and Travis integration then one of the repo owners needs to activate pkgcloud on coveralls.io and then switch the make target in the travis.yml.
