### PR TITLE
Added Rackspace DNS and Storage examples that were completely amiss.

### DIFF
--- a/examples/dns/rackspace.js
+++ b/examples/dns/rackspace.js
@@ -1,0 +1,77 @@
+var pkgcloud = require('../../lib/pkgcloud');
+var _		 = require('underscore');
+
+var rackspace = pkgcloud.dns.createClient({
+    provider: 'rackspace',
+    username: 'rax-user-id',
+    apiKey: '1234567890asdbchehe'
+  });
+
+// Basic DNS management operations. Please note that due to the asynchronous nature of JS programming,
+// the code sample below will cause unexpected results if run as-a-whole and are meant for documentation 
+// and illustration purposes.
+
+// 1 - Get all DNS "Zones" associates with your account
+rackspace.getZones({}, function (err, zones) {
+	if(!err && zones.length > 0) {
+		_.each(zones, function (z) { 
+			console.log(z.id + ' ' + z.name);
+		});
+	}
+});
+
+// 2 - Create a new "Zone". The details object has these required fields: name, admin email, 
+// ttl and comment are optional. *IMPORTANT*: Currently the service will check the domain name you are 
+// trying to use is actually registered. If it cannot find a record for it, it will error out.
+var details = {name: 'domain.name', email: 'admin@domain.name', ttl: 300, comment: 'I pity .foo'};
+rackspace.createZone(details, function (err, zone) {
+	if(!err) {
+		console.log(zone.id + ' ' + zone.name + ' ' + zone.ttl);
+	}
+});
+
+// 3 - Let's get the "Zone" we just created and let's see its records
+rackspace.getZones({name:'domain.name'}, function (err, zones) {
+	if(!err && zones.length > 0) {
+		console.log('We have parent Zone');
+		rackspace.getRecords(zones[0], function (err, records) {
+			if (!err) {
+				_.each(records, function (rec){
+					console.dir(rec);
+				});
+			}
+			else {
+				console.log('There was an error retrieving records: ' + err);
+			}
+		});
+	}
+});
+
+// 4 - Let's add a new DNS A-record to a "Zone". Record has three required fields: type, name, data
+var _rec = {name: 'sub.domain.name', type: 'A', data: '127.0.0.1'};
+rackspace.getZones({name:'domain.name'}, function (err, zones) {
+	if(!err && zones.length > 0) {
+		console.log('We have parent Zone');
+		rackspace.createRecord(zones[0], _rec, function (err, rec) {
+			if (!err) {
+				console.log('Record successfully created');
+				console.log(rec.name + ' ' + rec.data + ' ' + rec.ttl);
+			}
+		});
+	}
+});
+
+// 5 - Now let's remove the "Zone" and all of its children records.
+rackspace.getZones({name:'domain.name'}, function (err, zones) {
+	if(!err && zones.length > 0) {
+		console.log('We have parent Zone');
+		rackspace.deleteZone(zones[0], function (err) {
+			if (!err) {
+				console.log('Zone and records were successfully deleted');
+			}
+			else {
+				console.log('There was an error while deleting zone: ' + err);
+			}
+		});
+	}
+});

--- a/examples/storage/rackspace.js
+++ b/examples/storage/rackspace.js
@@ -1,7 +1,65 @@
 var pkgcloud = require('../../lib/pkgcloud');
+var os = require('os');
+var fs = require('fs');
 
 var rackspace = pkgcloud.storage.createClient({
   provider: 'rackspace',
-  username: 'nodejitsu',
-  apiKey: 'foobar'
+  username: 'rackspace_id',
+  apiKey: '1234567890poiiuytrrewq',
+  region: 'IAD'//storage requires region or else assumes default
+});
+
+// Basic container and file operations. Please note that due to the asynchronous nature of JS programming,
+// the code sample below will cause unexpected results if run as-a-whole and are meant for documentation 
+// and illustration purposes.
+
+
+//1 -- to create a container
+rackspace.createContainer({name: 'sample-container-test', metadata: {callme: "maybe"}}, function (err, container) {
+	if(!err) { 
+		console.log(container.name + os.EOL)
+		console.log(container.metadata)
+	}
+});
+
+//2 -- to list our containers
+rackspace.getContainers(function (err, containers) {
+	if(!err) {
+		for (var _i = 0; _i < containers.length; _i++) {
+			console.log(containers[_i].name + os.EOL)
+		}
+	}
+});
+
+// 3 -- to create a container and upload a file to it
+rackspace.createContainer({name: 'sample-container', metadata: {callme: "maybe"}}, function (err, container) {
+	if(!err) { 
+		var my_file = fs.createReadStream('/Users/pix/IMG_0076.JPG');
+		my_file.pipe(rackspace.upload({container: container.name, remote: 'profile-picture.jpg'},
+			function (err, result) {
+				if(!err) { 
+					console.log(result);
+				}
+			}));
+	}
+});
+
+//4 -- to get a container, empty it, then finally destroying it
+rackspace.getContainer('sample-container', function (err, container) {
+	if(!err) {
+		rackspace.getFiles(container, function (err, files) {
+			for(var _i = 0; _i < files.length; _i++) {
+				rackspace.removeFile(container, files[_i], function (err, result) {
+					if(!err) {
+						console.log('File deleted: ' + result);
+					}
+				});
+			}
+			rackspace.destroyContainer(container, function (err, result) {
+				if(!err) {
+					console.log('Container ' + container.name + ' was successfully destroyed.')
+				}
+			});
+		});
+	}
 });


### PR DESCRIPTION
In an effort to help developers new to pkgcloud manage rax resources, I have added examples of common usage and tasks for dns and storage. Will add more as needed and cover other pkgcloud rax services as well.
