### PR TITLE
[fix sec] Scrub data by default when destroying a DO droplet

### DIFF
--- a/lib/pkgcloud/digitalocean/compute/client/servers.js
+++ b/lib/pkgcloud/digitalocean/compute/client/servers.js
@@ -150,7 +150,10 @@ exports.destroyServer = function destroyServer(server, callback) {
       self = this;
 
   this.request({
-    path: '/droplets/' + serverId + '/destroy'
+    path: '/droplets/' + serverId + '/destroy',
+    qs: {
+      scrub_data: '1'
+    }
   }, function (err, body, res) {
     return err ? callback(err) : callback(null, { ok: serverId }, res);
   });

--- a/test/common/compute/base-test.js
+++ b/test/common/compute/base-test.js
@@ -512,6 +512,7 @@ function setupDestroyMock(client, provider, servers) {
 
     servers.server
       .get('/droplets/354526/destroy?' + qs.stringify({
+        scrub_data: '1',
         client_id: account.clientId,
         api_key: account.apiKey
       }))


### PR DESCRIPTION
Fixes #215.

We still should find a way to disable this behavior, but right now the only thing that comes to my mind is a flag on `server`.
