### PR TITLE
[openstack storage] update getFiles() to return all container files by default (>10k)

### DIFF
--- a/docs/providers/rackspace/storage.md
+++ b/docs/providers/rackspace/storage.md
@@ -283,7 +283,7 @@ By default, without the `limit` option being specified, a single request is made
 
 If `limit` is set to a be greater than 10,000, requests will be made until the limit is reached or all files in the container have been retrieved.
 
-If `limit` is 0, requests will be made until all files in the container have been retrieved.
+Set `limit` to the global `Infinity` to ensure a complete listing of the container.
 
 #### client.removeFile(container, file, function(err, result) { })
 

--- a/lib/pkgcloud/openstack/storage/client/files.js
+++ b/lib/pkgcloud/openstack/storage/client/files.js
@@ -217,7 +217,7 @@ exports.getFile = function (container, file, callback) {
  * client.getFiles
  *
  * @description get the list of files in a container. Returns at most 10,000 files if options.limit is unspecified.
- * Abstracts the aggregation of files in the case that options.limit is 0 or >10,000.
+ * Abstracts the aggregation of files in the case that options.limit is >10,000.
  *
  * @param {String|object}     container     the container or containerName
  * @param {object|Function}   options
@@ -234,15 +234,15 @@ exports.getFiles = function (container, options, callback) {
   }
 
   // If limit is not specified, or it is <=10k, just make a single request
-  if (typeof options.limit === 'undefined' || (options.limit > 0 && options.limit <= 10000)) {
+  if (!options.limit || options.limit <= 10000) {
     return this._getFiles(container, options, callback);
   }
 
-  // limit is specified and is 0 or >10k. Abstract the aggregation of files (cloudfiles returns max 10k at once)
+  // Limit is specified and is >10k. Abstract the aggregation of files (cloudfiles returns max 10k at once)
   var files = [];
 
-  // If the user passes 0 for limit, treat is as a full container listing
-  var remainingLimit = options.limit === 0 ? Infinity : options.limit;
+  // Keep track of how many files are left to collect
+  var remainingLimit = options.limit;
   delete options.limit;
 
   var getFilesCallback = function(err, someFiles) {

--- a/test/rackspace/storage/storage-object-test.js
+++ b/test/rackspace/storage/storage-object-test.js
@@ -176,7 +176,7 @@ describe('pkgcloud/rackspace/storage/stroage-object', function () {
       });
     });
 
-    it('getFiles with limit = 0 should return all files', function (done) {
+    it('getFiles with limit = Infinity should return all files', function (done) {
 
       if (!mock) {
         return done();
@@ -190,7 +190,7 @@ describe('pkgcloud/rackspace/storage/stroage-object', function () {
         .get('/v1/MossoCloudFS_00aa00aa-aa00-aa00-aa00-aa00aa00aa00/0.1.7-215?format=json&marker=FILE19999')
         .reply(200, []);
 
-      client.getFiles('0.1.7-215', { limit: 0 }, function (err, files) {
+      client.getFiles('0.1.7-215', { limit: Infinity }, function (err, files) {
         should.not.exist(err);
         should.exist(files);
         files.should.have.length(20000);


### PR DESCRIPTION
Cloudfiles will return a maximum of 10,000 files at once when listing a containers contents. Previously, listing a container with >10,000 objects required a pkgcloud user to use the `limit` and `marker` options to aggregate results. This update causes pkgcloud's `openstack.getFiles()` method to internally request additional files if 10,000 results were returned in the previous GET request.

The behavior of `getFiles()` remains unchanged if the user passes a `limit` or `marker` option.
