### PR TITLE
[fix api breaking] Only pass a callback to `Client.prototype.request` in...

### DIFF
--- a/lib/pkgcloud/amazon/storage/client/files.js
+++ b/lib/pkgcloud/amazon/storage/client/files.js
@@ -51,7 +51,18 @@ exports.upload = function (options, callback) {
     options = {};
   }
 
+  //
+  // Optional helper function passed to `this.request`
+  // in the case when no callback is passed to `.upload(options)`.
+  //
+  function onUpload(err, body, res) {
+    return err
+      ? callback(err)
+      : callback(null, res.statusCode == 200, res);
+  }
+
   var container = options.container,
+      success = callback ? onUpload : null,
       apiStream,
       inputStream;
 
@@ -88,14 +99,10 @@ exports.upload = function (options, callback) {
       container: container,
       path: options.remote,
       headers: options.headers || {}
-    }, function (err, body, res) {
-      return err
-        ? callback && callback(err)
-        : callback && callback(null, res.statusCode == 200, res);
-    });
+    }, success);
   } else {
     // Multi-part, 5mb chunk upload
-    apiStream = this.multipartUpload(options, callback);
+    apiStream = this.multipartUpload(options, success);
   }
 
   if (inputStream) {
@@ -281,9 +288,23 @@ exports.multipartUpload = function (options, callback) {
 
 exports.download = function (options, callback) {
   var self = this,
+      success = callback ? onDownload : null,
       container = options.container,
       inputStream,
       apiStream;
+
+  //
+  // Optional helper function passed to `this.request`
+  // in the case when no callback is passed to `.download(options)`.
+  //
+  function onDownload(err, body, res) {
+    return err
+      ? callback(err)
+      : callback(null, new (storage.File)(self, utile.mixin(res.headers, {
+          container: container,
+          name: options.remote
+        })));
+  }
 
   if (container instanceof storage.Container) {
     container = container.name;
@@ -300,14 +321,7 @@ exports.download = function (options, callback) {
     path: options.remote,
     container: container,
     download: true
-  }, function (err, body, res) {
-    return err
-      ? callback && callback(err)
-      : callback && callback(null, new (storage.File)(self, utile.mixin(res.headers, {
-        container: container,
-        name: options.remote
-      })));
-  });
+  }, success);
 
   if (inputStream) {
     apiStream.pipe(inputStream);

--- a/lib/pkgcloud/azure/storage/client/files.js
+++ b/lib/pkgcloud/azure/storage/client/files.js
@@ -49,10 +49,21 @@ exports.upload = function (options, callback) {
     options = {};
   }
 
+  //
+  // Optional helper function passed to `this.request`
+  // in the case when no callback is passed to `.upload(options)`.
+  //
+  function onUpload(err, body, res) {
+    return err
+      ? callback(err)
+      : callback(null, res.statusCode === 200 || res.statusCode === 201, res);
+  }
+
   var container = options.container,
-    path,
-    rstream,
-    lstream;
+      success = callback ? onUpload : null,
+      path,
+      rstream,
+      lstream;
 
   if (container instanceof storage.Container) {
     container = container.name;
@@ -91,14 +102,10 @@ exports.upload = function (options, callback) {
       path: path,
       headers: options.headers || {},
       qs: options.qs
-    }, function (err, body, res) {
-      return err
-        ? callback && callback(err)
-        : callback && callback(null, res.statusCode === 200 || res.statusCode === 201, res);
-    });
+    }, success);
   } else {
     // Multi-part, 5mb chunk upload
-    rstream = this.multipartUpload(options, callback);
+    rstream = this.multipartUpload(options, success);
   }
 
   if (lstream) lstream.pipe(rstream);
@@ -202,9 +209,23 @@ exports.sendBlockList = function (options, numBlocks, callback) {
 
 exports.download = function (options, callback) {
   var self = this,
-    container = options.container,
-    lstream,
-    rstream;
+      success = callback ? onDownload : null,
+      container = options.container,
+      lstream,
+      rstream;
+
+  //
+  // Optional helper function passed to `this.request`
+  // in the case when no callback is passed to `.download(options)`.
+  //
+  function onDownload(err, body, res) {
+    return err
+      ? callback(err)
+      : callback(null, new (storage.File)(self, utile.mixin(res.headers, {
+          container: container,
+          name: options.remote
+        })));
+  }
 
   if (container instanceof storage.Container) {
     container = container.name;
@@ -220,14 +241,7 @@ exports.download = function (options, callback) {
   rstream = this.request({
     path: urlJoin(container, options.remote),
     download: true
-  }, function (err, body, res) {
-    return err
-      ? callback && callback(err)
-      : callback && callback(null, new (storage.File)(self, utile.mixin(res.headers, {
-          container: container,
-          name: options.remote
-        })));
-  });
+  }, success);
 
   if (lstream) {
     rstream.pipe(lstream);

--- a/lib/pkgcloud/openstack/storage/client/files.js
+++ b/lib/pkgcloud/openstack/storage/client/files.js
@@ -65,7 +65,18 @@ exports.upload = function (options, callback) {
     options = {};
   }
 
+  //
+  // Optional helper function passed to `this.request`
+  // in the case when no callback is passed to `.upload(options)`.
+  //
+  function onUpload(err, body, res) {
+    return err
+      ? callback(err)
+      : callback(null, true, res);
+  }
+
   var container = options.container,
+      success = callback ? onUpload : null,
       self = this,
       apiStream,
       inputStream,
@@ -117,12 +128,7 @@ exports.upload = function (options, callback) {
       self.serializeMetadata(self.OBJECT_META_PREFIX, options.metadata));
   }
 
-  apiStream = this.request(uploadOptions, function (err, body, res) {
-    return err
-      ? callback && callback(err)
-      : callback && callback(null, true, res);
-  });
-
+  apiStream = this.request(uploadOptions, success);
   if (inputStream) {
     inputStream.pipe(apiStream);
   }
@@ -148,9 +154,23 @@ exports.upload = function (options, callback) {
  */
 exports.download = function (options, callback) {
   var self = this,
+      success = callback ? onDownload : null,
       container = options.container,
       inputStream,
       apiStream;
+
+  //
+  // Optional helper function passed to `this.request`
+  // in the case when no callback is passed to `.download(options)`.
+  //
+  function onDownload(err, body, res) {
+    return err
+      ? callback(err)
+      : callback(null, new (storage.File)(self, utile.mixin(res.headers, {
+          container: container,
+          name: options.remote
+        })));
+  }
 
   if (container instanceof storage.Container) {
     container = container.name;
@@ -167,14 +187,7 @@ exports.download = function (options, callback) {
     container: container,
     path: options.remote,
     download: true
-  }, function (err, body, res) {
-    return err
-      ? callback && callback(err)
-      : callback && callback(null, new (storage.File)(self, utile.mixin(res.headers, {
-          container: container,
-          name: options.remote
-        })));
-  });
+  }, success);
 
   if (inputStream) {
     apiStream.pipe(inputStream);


### PR DESCRIPTION
... `.upload(options, callback)` and `.download(options, callback)` methods when explicitly passed a callback by the user. Fixes #195
