### PR TITLE
[openstack storage] properly URI encode container and object names

### DIFF
--- a/lib/pkgcloud/openstack/storage/storageClient.js
+++ b/lib/pkgcloud/openstack/storage/storageClient.js
@@ -34,11 +34,11 @@ Client.prototype.getUrl = function (options) {
   var fragment = '';
 
   if (options.container) {
-    fragment = options.container;
+    fragment = encodeURIComponent(options.container);
   }
 
   if (options.path) {
-    fragment = urlJoin(fragment, options.path);
+    fragment = urlJoin(fragment, options.path.split('/').map(encodeURIComponent).join('/'));
   }
 
   if (fragment === '' || fragment === '/') {

--- a/test/rackspace/storage/container-test.js
+++ b/test/rackspace/storage/container-test.js
@@ -106,7 +106,7 @@ describe('pkgcloud/rackspace/storage/containers', function () {
             'x-trans-id': 'tx8a8acb8f3f7142c8bd36f27a18415996',
             date: 'Wed, 12 Jun 2013 19:04:25 GMT',
             connection: 'keep-alive' })
-          .head('/v1/MossoCloudFS_00aa00aa-aa00-aa00-aa00-aa00aa00aa00/0.1.3-85,')
+          .head('/v1/MossoCloudFS_00aa00aa-aa00-aa00-aa00-aa00aa00aa00/0.1.3-85%2C')
           .reply(204, '', {
             'x-cdn-ssl-uri': 'https://c98c1215ec09a78cd287-edfcb31ae70ea7c07367728d50539bc7.ssl.cf1.rackcdn.com',
             'x-ttl': '186400',
@@ -258,6 +258,38 @@ describe('pkgcloud/rackspace/storage/containers', function () {
         server && server.done();
         done();
       });
+    });
+
+    it('getContainer should URL encode container names', function (done) {
+      if (mock) {
+        server
+          .head('/v1/MossoCloudFS_00aa00aa-aa00-aa00-aa00-aa00aa00aa00/~!%40%23%24%25%5E%26*()_%2B')
+          .reply(200, '', { 'content-length': '0',
+            'x-container-object-count': '144',
+            'x-container-meta-awesome': 'Tue Jun 04 2013 07:58:52 GMT-0700 (PDT)',
+            'x-timestamp': '1368837729.84945',
+            'x-container-meta-foo': 'baz',
+            'x-container-bytes-used': '134015617',
+            'content-type': 'application/json; charset=utf-8',
+            'accept-ranges': 'bytes',
+            'x-trans-id': 'txb0bcacabf853476e87f846ff0e85a22f',
+            date: 'Thu, 13 Jun 2013 15:18:17 GMT',
+            connection: 'keep-alive' }
+          )
+          .head('/v1/MossoCloudFS_00aa00aa-aa00-aa00-aa00-aa00aa00aa00/~!%40%23%24%25%5E%26*()_%2B')
+          .reply(404);
+      }
+
+      client.getContainer('~!@#$%^&*()_+', function (err, container) {
+        should.not.exist(err);
+        should.exist(container);
+
+        container.should.be.instanceof(Container);
+
+        server && server.done();
+        done();
+      });
+
     });
 
     it('getContainer should include cdn metadata', function (done) {

--- a/test/rackspace/storage/storage-object-test.js
+++ b/test/rackspace/storage/storage-object-test.js
@@ -21,7 +21,7 @@ if (!mock) {
   return; // these tests are disabled when running for real
 }
 
-describe('pkgcloud/rackspace/storage/stroage-object', function () {
+describe('pkgcloud/rackspace/storage/storage-object', function () {
   describe('The pkgcloud Rackspace Storage client', function () {
 
     var client, server, authServer;
@@ -167,7 +167,23 @@ describe('pkgcloud/rackspace/storage/stroage-object', function () {
         done();
       });
     });
-    
+
+    it('getFile should URL encode the file name', function (done) {
+      if (mock) {
+        server
+          .head('/v1/MossoCloudFS_00aa00aa-aa00-aa00-aa00-aa00aa00aa00/0.1.7-215/~!%40%23%24%25%5E%26*()_%2B/~!%40%23%24%25%5E%26*()_%2B?format=json')
+          .reply(200);
+      }
+
+      client.getFile('0.1.7-215', '~!@#$%^&*()_+/~!@#$%^&*()_+', function (err, file) {
+        should.not.exist(err);
+        should.exist(file);
+        file.should.be.instanceof(File);
+        server && server.done();
+        done();
+      });
+    });
+
     it('extract should ask server to extract the uploaded tar file', function(done) {
       
       var data = "H4sIABub81EAA+3TzUrEMBAH8CiIeNKTXvMC1nxuVzx58CiC9uBNam1kQZt1N4X1XXwDX9IJXVi6UDxo6sH/D4akadJOmY7z/owlJkhubTdOulEo040dJpXMTS6tjuuSriTjNnViUbsM5YJztvCPs+atHdxH25wbI6FxOap/9hDqZcjCKqR5RyzwxJjB+iurN/WXiuqvpdGMizTp9P3z+rO94322y9h1WfGbO37P1+IaO6BQFO8U8fqzd/Jo6JGXRXG7nsYTHxSHW1t2NusnlX/Nyvn8pc6KehWumso/zZpnutkGdzq9kNrQv3E+Nb/yudAX+z9t93/f/0LIrf5XNEP/j0H+dQIAAAAAAAAAAAAAAAAAAADwY194ELb5ACgAAA==";


### PR DESCRIPTION
Rackspace container names can include any special characters except `/`, and object names have no restrictions. `pkgcloud` does not currently URL encode container or object names during requests, leading to unexpected results.

As an example,

``` javascript
client.createContainer('foo!@#$%', function(err, container) {
        console.log(container);
});
```

will succeed and return a `Container` object with `name : "foo!@#$%"`, however it will actually create a container named `foo!@`.

I can create a PR for this, but would it go into `0.9.0` or `master`?
