### PR TITLE
Throw error when provider not supported

### DIFF
--- a/lib/pkgcloud.js
+++ b/lib/pkgcloud.js
@@ -82,6 +82,10 @@ services.forEach(function (service) {
 
     var provider = pkgcloud.providers[options.provider];
 
+    if (!provider) {
+      throw new Error(options.provider + ' is not a supported provider');
+    }
+
     if (!provider[service]) {
       throw new Error(options.provider + ' does not expose a ' + service + ' service');
     }


### PR DESCRIPTION
Throw a useful error message when the provider given isn't supported. Perhaps this should list the supported providers (to combat typos, etc.)?
