### PR TITLE
Refactoring storage for openstack to allow per-provider models

### DIFF
--- a/lib/pkgcloud/openstack/storage/client/containers.js
+++ b/lib/pkgcloud/openstack/storage/client/containers.js
@@ -14,211 +14,210 @@ var async = require('async'),
     _ = require('underscore'),
     storage = pkgcloud.providers.openstack.storage;
 
-/**
- * client.getContainers
- *
- * @description get the list of containers for an account
- *
- * @param {object|Function}   options
- * @param {Number}            [options.limit]   the number of records to return
- * @param {String}            [options.marker]  Marker value. Operation returns object names that are greater than this value.
- * @param {String}            [options.end_marker]  Operation returns object names that are less than this value.
- * @param {Function}          callback
- */
-exports.getContainers = function (options, callback) {
-  var self = this;
+exports.enableContainers = function(Container) {
+  return {
+    /**
+     * client.getContainers
+     *
+     * @description get the list of containers for an account
+     *
+     * @param {object|Function}   options
+     * @param {Number}            [options.limit]   the number of records to return
+     * @param {String}            [options.marker]  Marker value. Operation returns object names that are greater than this value.
+     * @param {String}            [options.end_marker]  Operation returns object names that are less than this value.
+     * @param {Function}          callback
+     */
+    getContainers: function(options, callback) {
+      var self = this;
 
-  if (typeof options === 'function') {
-    callback = options;
-    options = {};
-  }
-
-  var getContainerOpts = {
-    path: '',
-    qs: _.extend({
-      format: 'json'
-    }, _.pick(options, ['limit', 'marker', 'end_marker']))
-  };
-
-  this._request(getContainerOpts, function (err, body) {
-    if (err) {
-      return callback(err);
-    }
-    else if (!body || !(body instanceof Array)) {
-      return new Error('Malformed API Response')
-    }
-
-    return callback(null, body.map(function (container) {
-      return new storage.Container(self, container);
-    }));
-  });
-};
-
-/**
- * client.getContainer
- *
- * @description get the details for a specific container
- *
- * @param {String|object}     container     the container or containerName
- * @param callback
- */
-exports.getContainer = function (container, callback) {
-  var containerName = container instanceof storage.Container ? container.name : container,
-    self = this;
-
-  this._request({
-    method: 'HEAD',
-    container: containerName
-  }, function (err, body, res) {
-    if (err) {
-      return callback(err);
-    }
-
-    var details = _.extend({}, body, {
-      name: containerName,
-      count: parseInt(res.headers['x-container-object-count'], 10),
-      bytes: parseInt(res.headers['x-container-bytes-used'], 10)
-    });
-
-    details.metadata = self.deserializeMetadata(self.CONTAINER_META_PREFIX, res.headers);
-
-    callback(null, new (storage.Container)(self, details));
-  });
-};
-
-/**
- * client.createContainer
- *
- * @description create a new container
- *
- * @param {object}    options
- * @param {String}    options.name      the name of the new container
- * @param {object}    [options.metadata]  optional metadata about the container
- * @param callback
- */
-exports.createContainer = function (options, callback) {
-  var containerName = typeof options === 'object' ? options.name : options,
-      self = this;
-
-  var createContainerOpts = {
-    method: 'PUT',
-    container: containerName
-  };
-
-  if (options.metadata) {
-    createContainerOpts.headers = self.serializeMetadata(self.CONTAINER_META_PREFIX, options.metadata);
-  }
-
-  this._request(createContainerOpts, function (err) {
-    return err
-      ? callback(err)
-      : callback(null, new (storage.Container)(self, { name: containerName, metadata: options.metadata }));
-  });
-};
-
-/**
- * client.updateContainerMetadata
- *
- * @description Updates the metadata in the specified `container` in
- * the storage container associated with this instance.
- *
- * @param {String|object}     container     the container or containerName
- * @param callback
- */
-exports.updateContainerMetadata = function (container, callback) {
-  this._updateContainerMetadata(container,
-    this.serializeMetadata(this.CONTAINER_META_PREFIX, container.metadata),
-    callback);
-};
-
-/**
- * client.updateContainerMetadata
- *
- * @description Removes the provided `metadata` in the specified
- * `container` in the storage container associated with this instance.
- *
- * @param {String|object}     container     the container or containerName
- * @param {object}            metadataToRemove     the metadata to remove from the container
- * @param callback
- */
-exports.removeContainerMetadata = function (container, metadataToRemove, callback) {
-  this._updateContainerMetadata(container,
-    this.serializeMetadata(this.CONTAINER_REMOVE_META_PREFIX, metadataToRemove),
-    callback);
-};
-
-/**
- * client._updateContainerMetadata
- *
- * @description Convenience function for updating container metadata
- */
-exports._updateContainerMetadata = function(container, metadata, callback) {
-  var self = this;
-
-  if (!(container instanceof base.Container)) {
-    throw new Error('Must update an existing container instance');
-  }
-
-  var updateContainerOpts = {
-    method: 'POST',
-    container: container.name,
-    headers: metadata
-  };
-
-  this._request(updateContainerOpts, function (err) {
-
-    // omit our newly deleted header fields, if any
-    if (!err) {
-      container.metadata = _.omit(container.metadata,
-        _.keys(self.deserializeMetadata(self.CONTAINER_REMOVE_META_PREFIX, metadata)));
-    }
-
-    return err
-      ? callback(err)
-      : callback(null, container);
-  });
-};
-
-/**
- * client.destroyContainer
- *
- * @description Delete the storage container and all files within it
- *
- * @param {String|object}     container     the container or containerName
- * @param callback
- */
-exports.destroyContainer = function (container, callback) {
-  var containerName = container instanceof base.Container ? container.name : container,
-      self = this;
-
-  this.getFiles(container, function (err, files) {
-    if (err) {
-      return callback(err);
-    }
-
-    function deleteContainer(err) {
-      if (err) {
-        return callback(err);
+      if (typeof options === 'function') {
+        callback = options;
+        options = {};
       }
 
-      self._request({
-        method: 'DELETE',
+      var getContainerOpts = {
+        path: '',
+        qs: _.extend({
+          format: 'json'
+        }, _.pick(options, ['limit', 'marker', 'end_marker']))
+      };
+
+      this._request(getContainerOpts, function (err, body) {
+        if (err) {
+          return callback(err);
+        }
+        else if (!body || !(body instanceof Array)) {
+          return new Error('Malformed API Response')
+        }
+
+        return callback(null, body.map(function (container) {
+          return new Container(self, container);
+        }));
+      });
+    },
+    /**
+     * client.getContainer
+     *
+     * @description get the details for a specific container
+     *
+     * @param {String|object}     container     the container or containerName
+     * @param callback
+     */
+    getContainer: function (container, callback) {
+      var containerName = container instanceof Container ? container.name : container,
+        self = this;
+
+      this._request({
+        method: 'HEAD',
         container: containerName
-      }, function(err) {
+      }, function (err, body, res) {
+        if (err) {
+          return callback(err);
+        }
+
+        var details = _.extend({}, body, {
+          name: containerName,
+          count: parseInt(res.headers['x-container-object-count'], 10),
+          bytes: parseInt(res.headers['x-container-bytes-used'], 10)
+        });
+
+        details.metadata = self.deserializeMetadata(self.CONTAINER_META_PREFIX, res.headers);
+
+        callback(null, new Container(self, details));
+      });
+    },
+    /**
+     * client.createContainer
+     *
+     * @description create a new container
+     *
+     * @param {object}    options
+     * @param {String}    options.name      the name of the new container
+     * @param {object}    [options.metadata]  optional metadata about the container
+     * @param callback
+     */
+    createContainer: function (options, callback) {
+      var containerName = typeof options === 'object' ? options.name : options,
+        self = this;
+
+      var createContainerOpts = {
+        method: 'PUT',
+        container: containerName
+      };
+
+      if (options.metadata) {
+        createContainerOpts.headers = self.serializeMetadata(self.CONTAINER_META_PREFIX, options.metadata);
+      }
+
+      this._request(createContainerOpts, function (err) {
         return err
           ? callback(err)
-          : callback(null, true);
+          : callback(null, new Container(self, { name: containerName, metadata: options.metadata }));
+      });
+    },
+    /**
+     * client.updateContainerMetadata
+     *
+     * @description Updates the metadata in the specified `container` in
+     * the storage container associated with this instance.
+     *
+     * @param {String|object}     container     the container or containerName
+     * @param callback
+     */
+    updateContainerMetadata: function (container, callback) {
+      this._updateContainerMetadata(container,
+        this.serializeMetadata(this.CONTAINER_META_PREFIX, container.metadata),
+        callback);
+    },
+    /**
+     * client.updateContainerMetadata
+     *
+     * @description Removes the provided `metadata` in the specified
+     * `container` in the storage container associated with this instance.
+     *
+     * @param {String|object}     container     the container or containerName
+     * @param {object}            metadataToRemove     the metadata to remove from the container
+     * @param callback
+     */
+    removeContainerMetadata: function (container, metadataToRemove, callback) {
+      this._updateContainerMetadata(container,
+        this.serializeMetadata(this.CONTAINER_REMOVE_META_PREFIX, metadataToRemove),
+        callback);
+    },
+    /**
+     * client._updateContainerMetadata
+     *
+     * @description Convenience function for updating container metadata
+     */
+    _updateContainerMetadata: function (container, metadata, callback) {
+      var self = this;
+
+      if (!(container instanceof Container)) {
+        throw new Error('Must update an existing container instance');
+      }
+
+      var updateContainerOpts = {
+        method: 'POST',
+        container: container.name,
+        headers: metadata
+      };
+
+      this._request(updateContainerOpts, function (err) {
+
+        // omit our newly deleted header fields, if any
+        if (!err) {
+          container.metadata = _.omit(container.metadata,
+            _.keys(self.deserializeMetadata(self.CONTAINER_REMOVE_META_PREFIX, metadata)));
+        }
+
+        return err
+          ? callback(err)
+          : callback(null, container);
+      });
+    },
+    /**
+     * client.destroyContainer
+     *
+     * @description Delete the storage container and all files within it
+     *
+     * @param {String|object}     container     the container or containerName
+     * @param callback
+     */
+    destroyContainer: function (container, callback) {
+      var containerName = container instanceof Container ? container.name : container,
+        self = this;
+
+      this.getFiles(container, function (err, files) {
+        if (err) {
+          return callback(err);
+        }
+
+        function deleteContainer(err) {
+          if (err) {
+            return callback(err);
+          }
+
+          self._request({
+            method: 'DELETE',
+            container: containerName
+          }, function (err) {
+            return err
+              ? callback(err)
+              : callback(null, true);
+          });
+        }
+
+        function destroyFile(file, next) {
+          file.remove(next);
+        }
+
+        if (files.length === 0) {
+          return deleteContainer();
+        }
+
+        async.forEach(files, destroyFile, deleteContainer);
       });
     }
-
-    function destroyFile(file, next) {
-      file.remove(next);
-    }
-
-    if (files.length === 0) {
-      return deleteContainer();
-    }
-
-    async.forEach(files, destroyFile, deleteContainer);
-  });
+  };
 };
+

--- a/lib/pkgcloud/openstack/storage/client/files.js
+++ b/lib/pkgcloud/openstack/storage/client/files.js
@@ -13,342 +13,338 @@ var fs = require('fs'),
     utile = require('utile'),
     base = require('../../../core/storage'),
     pkgcloud = require('../../../../pkgcloud'),
-    _ = require('underscore'),
-    storage = pkgcloud.providers.openstack.storage;
+    _ = require('underscore');
 
-/**
- * client.removeFile
- *
- * @description remove a file from a container
- *
- * @param {String|object}     container     the container or containerName
- * @param {String|object}     file          the file or fileName to delete
- * @param callback
- */
-exports.removeFile = function (container, file, callback) {
-  var containerName = container instanceof base.Container ? container.name : container,
-      fileName = file instanceof base.File ? file.name : file;
+exports.enableFiles = function(Container, File) {
+  return {
+    /**
+     * client.removeFile
+     *
+     * @description remove a file from a container
+     *
+     * @param {String|object}     container     the container or containerName
+     * @param {String|object}     file          the file or fileName to delete
+     * @param callback
+     */
+    removeFile: function (container, file, callback) {
+      var containerName = container instanceof Container ? container.name : container,
+        fileName = file instanceof File ? file.name : file;
 
-  this._request({
-      method: 'DELETE',
-      container: containerName,
-      path: fileName
-    }, function(err) {
-      return err
-        ? callback(err)
-        : callback(null, true);
-    }
-  );
-};
-
-/**
- * client.upload
- *
- * @description upload a new file to a container.
- * Returns the pipe interface so you can call:
- *
- * request('http://some.com/file.txt').pipe(client.upload(options));
- *
- * @param {object}          options
- * @param {String|object}   options.container   the container to store the file in
- * @param {String}          options.remote      the file name for the new file
- * @param {String}          [options.local]     an optional local file path to upload
- * @param {Stream}          [options.stream]    optionally explicitly provide the stream instead of pipe
- * @param {object}          [options.headers]   optionally provide headers for the call
- * @param {object}          [options.metadata]  optionally provide metadata for the object
- * @param callback
- * @returns {request|*}
- */
-exports.upload = function (options, callback) {
-  if (typeof options === 'function' && !callback) {
-    callback = options;
-    options = {};
-  }
-
-  //
-  // Optional helper function passed to `this._request`
-  // in the case when no callback is passed to `.upload(options)`.
-  //
-  function onUpload(err, body, res) {
-    return err
-      ? callback(err)
-      : callback(null, true, res);
-  }
-
-  var container = options.container,
-      success = callback ? onUpload : null,
-      self = this,
-      apiStream,
-      inputStream,
-      uploadOptions;
-
-  if (container instanceof storage.Container) {
-    container = container.name;
-  }
-
-  uploadOptions = {
-    method: 'PUT',
-    upload: true,
-    container: container,
-    path: options.remote,
-    headers: options.headers || {}
-  };
-
-  if (options.local) {
-    inputStream = filed(options.local);
-    uploadOptions.headers['content-length'] = fs.statSync(options.local).size;
-  }
-  else if (options.stream) {
-    inputStream = options.stream;
-  }
-
-  if (!uploadOptions.headers['content-type']) {
-    uploadOptions.headers['content-type'] = mime.lookup(options.remote);
-  }
-
-  // If the inputStream is a request stream, headers are automatically
-  // copied from the source stream to the destination stream.
-  // As CloudFiles uses ETag to compute an md5 hash, this leads to a case
-  // where a remote resource with an ETag, piped via request to CloudFiles with
-  // pkgcloud, would result in a 422 "Unable to Process" error.
-  //
-  // As a result, we explicitly only opt in 'Content-Type' and 'Content-Length'
-  // if there is a response handler on the inputStream
-  if (inputStream) {
-    inputStream.on('response', function(response) {
-      response.headers = {
-        'content-type': response.headers['content-type'],
-        'content-length': response.headers['content-length']
+      this._request({
+          method: 'DELETE',
+          container: containerName,
+          path: fileName
+        }, function (err) {
+          return err
+            ? callback(err)
+            : callback(null, true);
+        }
+      );
+    },
+    /**
+     * client.upload
+     *
+     * @description upload a new file to a container.
+     * Returns the pipe interface so you can call:
+     *
+     * request('http://some.com/file.txt').pipe(client.upload(options));
+     *
+     * @param {object}          options
+     * @param {String|object}   options.container   the container to store the file in
+     * @param {String}          options.remote      the file name for the new file
+     * @param {String}          [options.local]     an optional local file path to upload
+     * @param {Stream}          [options.stream]    optionally explicitly provide the stream instead of pipe
+     * @param {object}          [options.headers]   optionally provide headers for the call
+     * @param {object}          [options.metadata]  optionally provide metadata for the object
+     * @param callback
+     * @returns {request|*}
+     */
+    upload: function (options, callback) {
+      if (typeof options === 'function' && !callback) {
+        callback = options;
+        options = {};
       }
-    });
-  }
 
-  if (options.metadata) {
-    uploadOptions.headers = _.extend(uploadOptions.headers,
-      self.serializeMetadata(self.OBJECT_META_PREFIX, options.metadata));
-  }
+      //
+      // Optional helper function passed to `this._request`
+      // in the case when no callback is passed to `.upload(options)`.
+      //
+      function onUpload(err, body, res) {
+        return err
+          ? callback(err)
+          : callback(null, true, res);
+      }
 
-  apiStream = this._request(uploadOptions, success);
-  if (inputStream) {
-    inputStream.pipe(apiStream);
-  }
+      var container = options.container,
+        success = callback ? onUpload : null,
+        self = this,
+        apiStream,
+        inputStream,
+        uploadOptions;
 
-  return apiStream;
-};
+      if (container instanceof Container) {
+        container = container.name;
+      }
 
-/**
- * client.download
- *
- * @description download a file from a container
- * Returns the pipe interface so you can call:
- *
- * client.download(options).pipe(fs.createWriteStream(options2));
- *
- * @param {object}          options
- * @param {String|object}   options.container   the container to store the file in
- * @param {String}          options.remote      the file name for the new file
- * @param {String}          [options.local]     an optional local file path to download to
- * @param {Stream}          [options.stream]    optionally explicitly provide the stream instead of pipe
- * @param callback
- * @returns {request|*}
- */
-exports.download = function (options, callback) {
-  var self = this,
-      success = callback ? onDownload : null,
-      container = options.container,
-      inputStream,
-      apiStream;
+      uploadOptions = {
+        method: 'PUT',
+        upload: true,
+        container: container,
+        path: options.remote,
+        headers: options.headers || {}
+      };
 
-  //
-  // Optional helper function passed to `this._request`
-  // in the case when no callback is passed to `.download(options)`.
-  //
-  function onDownload(err, body, res) {
-    return err
-      ? callback(err)
-      : callback(null, new (storage.File)(self, utile.mixin(res.headers, {
+      if (options.local) {
+        inputStream = filed(options.local);
+        uploadOptions.headers['content-length'] = fs.statSync(options.local).size;
+      }
+      else if (options.stream) {
+        inputStream = options.stream;
+      }
+
+      if (!uploadOptions.headers['content-type']) {
+        uploadOptions.headers['content-type'] = mime.lookup(options.remote);
+      }
+
+      // If the inputStream is a request stream, headers are automatically
+      // copied from the source stream to the destination stream.
+      // As CloudFiles uses ETag to compute an md5 hash, this leads to a case
+      // where a remote resource with an ETag, piped via request to CloudFiles with
+      // pkgcloud, would result in a 422 "Unable to Process" error.
+      //
+      // As a result, we explicitly only opt in 'Content-Type' and 'Content-Length'
+      // if there is a response handler on the inputStream
+      if (inputStream) {
+        inputStream.on('response', function (response) {
+          response.headers = {
+            'content-type': response.headers['content-type'],
+            'content-length': response.headers['content-length']
+          }
+        });
+      }
+
+      if (options.metadata) {
+        uploadOptions.headers = _.extend(uploadOptions.headers,
+          self.serializeMetadata(self.OBJECT_META_PREFIX, options.metadata));
+      }
+
+      apiStream = this._request(uploadOptions, success);
+      if (inputStream) {
+        inputStream.pipe(apiStream);
+      }
+
+      return apiStream;
+    },
+    /**
+     * client.download
+     *
+     * @description download a file from a container
+     * Returns the pipe interface so you can call:
+     *
+     * client.download(options).pipe(fs.createWriteStream(options2));
+     *
+     * @param {object}          options
+     * @param {String|object}   options.container   the container to store the file in
+     * @param {String}          options.remote      the file name for the new file
+     * @param {String}          [options.local]     an optional local file path to download to
+     * @param {Stream}          [options.stream]    optionally explicitly provide the stream instead of pipe
+     * @param callback
+     * @returns {request|*}
+     */
+    download: function (options, callback) {
+      var self = this,
+        success = callback ? onDownload : null,
+        container = options.container,
+        inputStream,
+        apiStream;
+
+      //
+      // Optional helper function passed to `this._request`
+      // in the case when no callback is passed to `.download(options)`.
+      //
+      function onDownload(err, body, res) {
+        return err
+          ? callback(err)
+          : callback(null, new File(self, utile.mixin(res.headers, {
           container: container,
           name: options.remote
         })));
-  }
+      }
 
-  if (container instanceof storage.Container) {
-    container = container.name;
-  }
+      if (container instanceof Container) {
+        container = container.name;
+      }
 
-  if (options.local) {
-    inputStream = filed(options.local);
-  }
-  else if (options.stream) {
-    inputStream = options.stream;
-  }
+      if (options.local) {
+        inputStream = filed(options.local);
+      }
+      else if (options.stream) {
+        inputStream = options.stream;
+      }
 
-  apiStream = this._request({
-    container: container,
-    path: options.remote,
-    download: true
-  }, success);
+      apiStream = this._request({
+        container: container,
+        path: options.remote,
+        download: true
+      }, success);
 
-  if (inputStream) {
-    apiStream.pipe(inputStream);
-  }
+      if (inputStream) {
+        apiStream.pipe(inputStream);
+      }
 
-  return apiStream;
-};
+      return apiStream;
+    },
+    /**
+     * client.getFile
+     *
+     * @description get the details for a specific file
+     *
+     * @param {String|object}     container     the container or containerName
+     * @param {String|object}     file          the file or fileName to get details for
+     * @param callback
+     */
+    getFile: function (container, file, callback) {
+      var containerName = container instanceof Container ? container.name : container,
+        self = this;
 
-/**
- * client.getFile
- *
- * @description get the details for a specific file
- *
- * @param {String|object}     container     the container or containerName
- * @param {String|object}     file          the file or fileName to get details for
- * @param callback
- */
-exports.getFile = function (container, file, callback) {
-  var containerName = container instanceof base.Container ? container.name : container,
-      self = this;
-
-  this._request({
-    method: 'HEAD',
-    container: containerName,
-    path: file,
-    qs: {
-      format: 'json'
-    }
-  }, function (err, body, res) {
-    return err
-      ? callback(err)
-      : callback(null, new storage.File(self, utile.mixin(res.headers, {
+      this._request({
+        method: 'HEAD',
+        container: containerName,
+        path: file,
+        qs: {
+          format: 'json'
+        }
+      }, function (err, body, res) {
+        return err
+          ? callback(err)
+          : callback(null, new File(self, utile.mixin(res.headers, {
           container: container,
           name: file
         })));
-  });
-};
+      });
+    },
+    /**
+     * client.getFiles
+     *
+     * @description get the list of files in a container. Returns at most 10,000 files if options.limit is unspecified.
+     * Abstracts the aggregation of files in the case that options.limit is >10,000.
+     *
+     * @param {String|object}     container     the container or containerName
+     * @param {object|Function}   options
+     * @param {Number}            [options.limit]   the number of records to return
+     * @param {String}            [options.marker]  the id of the first record to return in the current query
+     * @param {Function}          callback
+     */
+    getFiles: function (container, options, callback) {
+      var self = this;
 
-/**
- * client.getFiles
- *
- * @description get the list of files in a container. Returns at most 10,000 files if options.limit is unspecified.
- * Abstracts the aggregation of files in the case that options.limit is >10,000.
- *
- * @param {String|object}     container     the container or containerName
- * @param {object|Function}   options
- * @param {Number}            [options.limit]   the number of records to return
- * @param {String}            [options.marker]  the id of the first record to return in the current query
- * @param {Function}          callback
- */
-exports.getFiles = function (container, options, callback) {
-  var self = this;
-
-  if (typeof options === 'function') {
-    callback = options;
-    options = {};
-  }
-
-  // If limit is not specified, or it is <=10k, just make a single request
-  if (!options.limit || options.limit <= 10000) {
-    return this._getFiles(container, options, callback);
-  }
-
-  // Limit is specified and is >10k. Abstract the aggregation of files (cloudfiles returns max 10k at once)
-  var files = [];
-
-  // Keep track of how many files are left to collect
-  var remainingLimit = options.limit;
-  delete options.limit;
-
-  var getFilesCallback = function(err, someFiles) {
-    if (err) {
-      return callback(err);
-    }
-
-    files = files.concat(someFiles);
-    remainingLimit -= someFiles.length;
-
-    // Check if we should attempt to retrieve more results
-    if (remainingLimit > 0 && someFiles.length === 10000) {
-      options.marker = someFiles.pop().name;
-
-      // Once the remainingLimit value becomes < 10000, we must pass it
-      if (remainingLimit < 10000) {
-        options.limit = remainingLimit;
+      if (typeof options === 'function') {
+        callback = options;
+        options = {};
       }
 
-      self._getFiles(container, options, getFilesCallback);
-    } else {
-      callback(null, files);
+      // If limit is not specified, or it is <=10k, just make a single request
+      if (!options.limit || options.limit <= 10000) {
+        return this._getFiles(container, options, callback);
+      }
+
+      // Limit is specified and is >10k. Abstract the aggregation of files (cloudfiles returns max 10k at once)
+      var files = [];
+
+      // Keep track of how many files are left to collect
+      var remainingLimit = options.limit;
+      delete options.limit;
+
+      var getFilesCallback = function (err, someFiles) {
+        if (err) {
+          return callback(err);
+        }
+
+        files = files.concat(someFiles);
+        remainingLimit -= someFiles.length;
+
+        // Check if we should attempt to retrieve more results
+        if (remainingLimit > 0 && someFiles.length === 10000) {
+          options.marker = someFiles.pop().name;
+
+          // Once the remainingLimit value becomes < 10000, we must pass it
+          if (remainingLimit < 10000) {
+            options.limit = remainingLimit;
+          }
+
+          self._getFiles(container, options, getFilesCallback);
+        } else {
+          callback(null, files);
+        }
+      };
+
+      this._getFiles(container, options, getFilesCallback);
+    },
+    _getFiles: function (container, options, callback) {
+      var containerName = container instanceof Container ? container.name : container,
+        self = this;
+
+      var getFilesOpts = {
+        path: containerName,
+        qs: {
+          format: 'json'
+        }
+      };
+
+      if (options.limit) {
+        getFilesOpts.qs.limit = options.limit;
+      }
+
+      if (options.marker) {
+        getFilesOpts.qs.marker = options.marker;
+      }
+
+      this._request(getFilesOpts, function (err, body) {
+
+        if (err) {
+          return callback(err);
+        }
+        else if (!body || !(body instanceof Array)) {
+          return new Error('Malformed API Response')
+        }
+
+        return callback(null, body.map(function (file) {
+          file.container = container;
+          return new File(self, file);
+        }));
+      });
+    }, /**
+     * client.updateFileMetadata
+     *
+     * @description Updates the specified `file` with the provided metadata `headers`
+     * in the Rackspace Cloud Files account associated with this instance.
+     *
+     * @param {String|object}     container     the container or containerName
+     * @param {String|object}     file          the file or fileName to update
+     * @param callback
+     */
+    updateFileMetadata: function (container, file, callback) {
+      var self = this,
+        containerName = container instanceof Container ? container.name : container;
+
+      if (!file instanceof File) {
+        throw new Error('Must update an existing file instance');
+      }
+
+      var updateFileOpts = {
+        method: 'POST',
+        container: containerName,
+        path: file.name,
+        headers: self.serializeMetadata(self.OBJECT_META_PREFIX, file.metadata)
+      };
+
+      this._request(updateFileOpts, function (err) {
+        return err
+          ? callback(err)
+          : callback(null, file);
+      });
     }
-  };
-
-  this._getFiles(container, options, getFilesCallback);
-};
-
-exports._getFiles = function (container, options, callback) {
-  var containerName = container instanceof base.Container ? container.name : container,
-      self = this;
-
-  var getFilesOpts = {
-    path: containerName,
-    qs: {
-      format: 'json'
-    }
-  };
-
-  if (options.limit) {
-    getFilesOpts.qs.limit = options.limit;
   }
-
-  if (options.marker) {
-    getFilesOpts.qs.marker = options.marker;
-  }
-
-  this._request(getFilesOpts, function (err, body) {
-
-    if (err) {
-      return callback(err);
-    }
-    else if (!body || !(body instanceof Array)) {
-      return new Error('Malformed API Response')
-    }
-
-    return callback(null, body.map(function (file) {
-      file.container = container;
-      return new storage.File(self, file);
-    }));
-  });
-};
-
-/**
- * client.updateFileMetadata
- *
- * @description Updates the specified `file` with the provided metadata `headers`
- * in the Rackspace Cloud Files account associated with this instance.
- *
- * @param {String|object}     container     the container or containerName
- * @param {String|object}     file          the file or fileName to update
- * @param callback
- */
-exports.updateFileMetadata = function (container, file, callback) {
-  var self = this,
-      containerName = container instanceof base.Container ? container.name : container;
-
-  if (!file instanceof base.File) {
-    throw new Error('Must update an existing file instance');
-  }
-
-  var updateFileOpts = {
-    method: 'POST',
-    container: containerName,
-    path: file.name,
-    headers: self.serializeMetadata(self.OBJECT_META_PREFIX, file.metadata)
-  };
-
-  this._request(updateFileOpts, function (err) {
-    return err
-      ? callback(err)
-      : callback(null, file);
-  });
 };
 
 

--- a/lib/pkgcloud/openstack/storage/client/index.js
+++ b/lib/pkgcloud/openstack/storage/client/index.js
@@ -10,13 +10,15 @@ var utile = require('utile'),
     urlJoin = require('url-join'),
     openstack = require('../../client'),
     StorageClient = require('../storageClient').StorageClient,
+    Container = require('../container').Container,
+    File = require('../file').File,
     _ = require('underscore');
 
 var Client = exports.Client = function (options) {
   openstack.Client.call(this, options);
 
-  utile.mixin(this, require('./containers'));
-  utile.mixin(this, require('./files'));
+  utile.mixin(this, require('./containers').enableContainers(Container));
+  utile.mixin(this, require('./files').enableFiles(Container, File));
 
   this.serviceType = 'object-store';
 };

--- a/lib/pkgcloud/rackspace/storage/client/index.js
+++ b/lib/pkgcloud/rackspace/storage/client/index.js
@@ -8,13 +8,15 @@
 var utile = require('utile'),
     rackspace = require('../../client'),
     StorageClient = require('../../../openstack/storage/storageClient').StorageClient,
+    Container = require('../container').Container,
+    File = require('../file').File,
     _ = require('underscore');
 
 var Client = exports.Client = function (options) {
   rackspace.Client.call(this, options);
 
-  utile.mixin(this, require('../../../openstack/storage/client/containers'));
-  utile.mixin(this, require('../../../openstack/storage/client/files'));
+  utile.mixin(this, require('../../../openstack/storage/client/containers').enableContainers(Container));
+  utile.mixin(this, require('../../../openstack/storage/client/files').enableFiles(Container, File));
   utile.mixin(this, require('./archive'));
   utile.mixin(this, require('./cdn-containers'));
   utile.mixin(this, require('./files'));

--- a/lib/pkgcloud/rackspace/storage/container.js
+++ b/lib/pkgcloud/rackspace/storage/container.js
@@ -34,6 +34,10 @@ Container.prototype.enableCdn = function (callback) {
   this.client.setCdnEnabled(this, callback);
 };
 
+Container.prototype.disableCdn = function (callback) {
+  this.client.setCdnEnabled(this, false, callback);
+};
+
 Container.prototype.updateCdn = function (options, callback) {
   this.client.updateCdnContainer(this, options, callback);
 };


### PR DESCRIPTION
This change introduces the ability to provide a `File` and `Container` model to the files and containers api when mixing in the client functionality.

Thus, the `openstack` provider can use the `openstack` models, and the `rackspace` provider can use the `rackspace` models.
- Fixes #269
