### PR TITLE
[openstack] Do not require explicit region when there is only one available

### DIFF
--- a/lib/pkgcloud/openstack/context/service.js
+++ b/lib/pkgcloud/openstack/context/service.js
@@ -75,8 +75,8 @@ Service.prototype.getEndpointUrl = function (options) {
         return;
       }
 
-      // return the first region-less endpoint
-      if (!endpoint.region) {
+      // return the first region-less endpoint or the single available region's endpoint
+      if (!endpoint.region || self.endpoints.length == 1) {
         url = getUrl(endpoint);
       }
     });

--- a/test/openstack/identity/service-test.js
+++ b/test/openstack/identity/service-test.js
@@ -116,5 +116,22 @@ describe('pkgcloud openstack context Service Class', function() {
 
     service.getEndpointUrl().should.equal('http://volume.myownendpoint.org:8776/v1/72e90ecb69c44d0296072ea39e537041');
   });
-});
 
+  it('with valid options getEndpointUrl without region when single region is available return correctly', function () {
+    var service = new context.Service({
+        "endpoints": [
+          {
+            "adminURL": "http://10.225.0.9:8776/v1/72e90ecb69c44d0296072ea39e537041",
+            "internalURL": "http://10.225.0.9:8776/v1/72e90ecb69c44d0296072ea39e537041",
+            "publicURL": "http://volume2.myownendpoint.org:8776/v1/72e90ecb69c44d0296072ea39e537041",
+            "region": "ORD"
+          }
+        ],
+        "endpoints_links": [],
+        "type": "volume",
+        "name": "volume"
+      });
+
+    service.getEndpointUrl().should.equal('http://volume2.myownendpoint.org:8776/v1/72e90ecb69c44d0296072ea39e537041');
+  });
+});


### PR DESCRIPTION
This fixes a regression of https://github.com/pkgcloud/pkgcloud/pull/116
When there's a single named region in the environment, don't require it to be specified when the client is created.
