### PR TITLE
(fix) amzn container model attempts to use this.files [storage]

### DIFF
--- a/lib/pkgcloud/core/storage/container.js
+++ b/lib/pkgcloud/core/storage/container.js
@@ -9,9 +9,9 @@ var utile = require('utile'),
     model = require('../base/model');
 
 var Container = exports.Container = function (client, details) {
-  model.Model.call(this, client, details);
-
   this.files = [];
+
+  model.Model.call(this, client, details);
 };
 
 utile.inherits(Container, model.Model);


### PR DESCRIPTION
The line linked below references this.files, which is called by the Model instantiation when using `getContainer`

https://github.com/omsmith/pkgcloud/blob/master/lib/pkgcloud/amazon/storage/container.js#L38
