### PR TITLE
(fix) handleResponse being called very incorrectly in s3 multipart [storage]

### DIFF
--- a/lib/pkgcloud/amazon/storage/client/files.js
+++ b/lib/pkgcloud/amazon/storage/client/files.js
@@ -278,9 +278,7 @@ exports.multipartUpload = function (options, callback) {
         'Content-Length': Buffer.byteLength(body)
       },
       body: body
-    }, function (err, body, res) {
-      handleResponse(err, res.statusCode == 200);
-    });
+    }, handleResponse);
   }
 
   return stream;


### PR DESCRIPTION
`handleResponse` expects `err, body, res`...

https://github.com/pkgcloud/pkgcloud/blob/master/lib/pkgcloud/amazon/storage/client/files.js#L130
