### PR TITLE
Changed branding to use HP Helion branding for HP provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Currently there are six service types which are handled by pkgcloud:
 * [DNS](#dns----beta) *(beta)*
 * [Block Storage](#block-storage----beta) *(beta)*
 * [Load Balancers](#load-balancers----beta) *(beta)*
-* [Network](#dns----beta) *(beta)*
+* [Network](#network----beta) *(beta)*
 
 In our [Roadmap](#roadmap), we plan to add support for more services, such as Queueing, Monitoring, and more. Additionally, we plan to implement more providers for the *beta* services, thus moving them out of *beta*.
 

--- a/docs/providers/hp/README.md
+++ b/docs/providers/hp/README.md
@@ -1,13 +1,16 @@
-## Using the HP Cloud provider in pkgcloud
+![HP Helion icon](http://www8.hp.com/hpnext/sites/default/files/content/documents/HP%20Helion%20Logo_Cloud_Martin%20Fink_New%20Style%20of%20IT_Hewlett-Packard.PNG)
 
-The HP Cloud provider in pkgcloud supports the following services:
+## Using the HP Helion Cloud provider in pkgcloud
+
+The HP  Helion Cloud provider in pkgcloud supports the following services:
 
 * [**Compute**](compute.md) (cloud compute)
+* [**Network**](network.md) (network)
 * [**Storage**](storage.md) (object storage)
 
-### Activating your HP Cloud services
+### Activating your HP  Helion Cloud services
 
-If this is your first time using HP Cloud Services, please follow [this](https://community.hpcloud.com/article/hp-public-cloud-quick-start-guide) guide to get started.
+If this is your first time using HP  Helion Cloud Services, please follow [this](https://community.hpcloud.com/article/hp-public-cloud-quick-start-guide) guide to get started.
 ### Getting Started with Compute
 
 We've provided a [simple compute example](getting-started-compute.md) where it creates a couple of compute instances.

--- a/docs/providers/hp/compute.md
+++ b/docs/providers/hp/compute.md
@@ -1,4 +1,6 @@
-##Using the HP Cloud Compute provider
+![HP Helion icon](http://www8.hp.com/hpnext/sites/default/files/content/documents/HP%20Helion%20Logo_Cloud_Martin%20Fink_New%20Style%20of%20IT_Hewlett-Packard.PNG)
+
+##Using the HP  Helion Cloud Compute provider
 
 Creating a client is straight-forward:
 

--- a/docs/providers/hp/getting-started-compute.md
+++ b/docs/providers/hp/getting-started-compute.md
@@ -1,8 +1,8 @@
-# Getting started with pkgcloud & HP
-
+![HP Helion icon](http://www8.hp.com/hpnext/sites/default/files/content/documents/HP%20Helion%20Logo_Cloud_Martin%20Fink_New%20Style%20of%20IT_Hewlett-Packard.PNG)
+# Getting started with pkgcloud & HP Helion Cloud
 The HP node.js SDK is available as part of `pkgcloud`, a multi-provider cloud provisioning package
 
-Pkgcloud currently supports HP Cloud Compute and HP Cloud Object Storage.
+Pkgcloud currently supports HP Helion Cloud Compute and HP Helion Cloud Object Storage, and HP Helion Cloud Networking.
 
 To install `pkgcloud` from the command line:
 
@@ -14,7 +14,7 @@ Don't have `npm` or `node` yet? [Get it now](http://nodejs.org/download).
 
 ## Using pkgcloud
 
-In this example, we're going to create a HP Cloud Compute client, create two servers, and then output their details to the command line.
+In this example, we're going to create a HP Helion Cloud Compute client, create two servers, and then output their details to the command line.
 
 *Note: We're going to use [underscore.js](http://underscorejs.org) for some convenience functions.*
 

--- a/docs/providers/hp/network.md
+++ b/docs/providers/hp/network.md
@@ -1,3 +1,5 @@
+![HP Helion icon](http://www8.hp.com/hpnext/sites/default/files/content/documents/HP%20Helion%20Logo_Cloud_Martin%20Fink_New%20Style%20of%20IT_Hewlett-Packard.PNG)
+
 ##Using the HP Cloud Network provider
 
 Creating a client is straight-forward:

--- a/docs/providers/hp/storage.md
+++ b/docs/providers/hp/storage.md
@@ -1,3 +1,5 @@
+![HP Helion icon](http://www8.hp.com/hpnext/sites/default/files/content/documents/HP%20Helion%20Logo_Cloud_Martin%20Fink_New%20Style%20of%20IT_Hewlett-Packard.PNG)
+
 ## Using the HP Object Storage provider
 
 * Container


### PR DESCRIPTION
Since HP Cloud changed its branding to HP Helion, updating the pkgcloud documentation to be the same.
