### PR TITLE
added in {name: db} object model to RS db users.js.  Replaced 'database'...

### DIFF
--- a/lib/pkgcloud/rackspace/database/client/users.js
+++ b/lib/pkgcloud/rackspace/database/client/users.js
@@ -50,7 +50,7 @@ exports.createUser = function createUser(options, callback) {
       calledBack = false;
 
     // Check for required options.
-    ['username', 'password', 'database', 'instance'].forEach(function (required) {
+    ['username', 'password', 'databases', 'instance'].forEach(function (required) {
       if (!opts[required]) {
         if (calledBack) { return; }
         errs.handle(errs.create({
@@ -88,19 +88,19 @@ exports.createUser = function createUser(options, callback) {
         opts['databases'].length > 0) {
       opts['databases'].forEach(function (item, idx) {
         if (typeof item === 'string') {
-          databases.push(item);
+          databases.push({ 'name' : item });
         } else if (item instanceof Database) {
-          databases.push(item.name);
+          databases.push({ 'name' : item.name });
         }
       });
     }
 
     if (opts && opts['databases'] && typeof opts['databases'] === 'string') {
-      databases.push(opts['databases']);
+      databases.push({ 'name' : opts['databases'] });
     }
 
     if (opts && opts['databases'] && opts['databases'] instanceof Database) {
-      databases.push(opts['databases'].name);
+      databases.push({ 'name' : opts['databases'].name });
     }
     // Check for invalid characters and permitted length of database
     databases.forEach(function (db) {


### PR DESCRIPTION
... with 'databases' in opts check.

Looks like the Rackspace API may have changed to require the database items to be objects of the form { name : database } instead of simply passing in the database name as a string:

http://docs.rackspace.com/cdb/api/v1.0/cdb-devguide/content/POST_createUser__version___accountId__instances__instanceId__users_user_management.html#POST_createUser__version___accountId__instances__instanceId__users_

There were also problems with the check for opts['database'] since all of the push operations were performed on opts['databases'].  I simply changed the check to look for databases instead; while this may break some compatibility with code already using 'database', it isn't working as is so will need an update regardless.  With that said, I also put together a commit that has functionality for both 'database' and 'databases' side by side... Let me know if ya'll would rather I submit that one.
