### PR TITLE
Allow AWS client against non-https servers

### DIFF
--- a/lib/pkgcloud/amazon/storage/client/index.js
+++ b/lib/pkgcloud/amazon/storage/client/index.js
@@ -50,10 +50,10 @@ Client.prototype._getUrl = function (options) {
   options = options || {};
 
   if (typeof options === 'string') {
-    return urlJoin('https://' + this.serversUrl, options);
+    return urlJoin(this.protocol + this.serversUrl, options);
   }
 
-  return urlJoin('https://' +
+  return urlJoin(this.protocol +
     (options.container ? options.container + '.' : '') +
     this.serversUrl, options.path);
 };


### PR DESCRIPTION
I want to test my application against a "fake" local S3.  It is not running HTTPS.  This change allows me to specify a non-HTTPS connection by passing { protocol: 'http://' } to the client creation as an option.
