### PR TITLE
[V1.0] Add Basic Support for Rackspace Static Website

### DIFF
--- a/lib/pkgcloud/rackspace/storage/client/cdn-containers.js
+++ b/lib/pkgcloud/rackspace/storage/client/cdn-containers.js
@@ -315,24 +315,27 @@ exports._getCdnContainerDetails = function(container, callback) {
 };
 
 /**
- * client.setStaticWebsiteIndexPage
+ * client.setStaticWebsite
  *
  * @description set the static website index page on a storage container
  *
  * @param {String|object}     container     the container or containerName
  * @param {object}            options       an object with options
  * @param {String}            options.indexFile       configure the static website index file for this container
+ * @param {String}            options.errorFile       configure the static website error file for this container
  * @param callback
  */
-exports.setStaticWebsiteIndexPage = function (container, options, callback) {
-  var indexFile = options.indexFile;
+exports.setStaticWebsite = function (container, options, callback) {
+  var indexFile = options.indexFile, errorFile = options.errorFile;
 
   if (typeof options === 'function') {
     callback = options;
     indexFile = 'index.html';
+    errorFile = 'error.html';
   }
 
   container.metadata['web-index'] = indexFile;
+  container.metadata['web-error'] = errorFile;
 
   this.updateContainerMetadata(container, callback);
 };
@@ -340,15 +343,19 @@ exports.setStaticWebsiteIndexPage = function (container, options, callback) {
 /**
  * client.removeStaticWebsite
  *
- * @description remove the static website index page on a storage container
+ * @description remove the static website index/error page on a storage container
  *
  * @param {String|object}     container     the container or containerName
  * @param callback
  */
 exports.removeStaticWebsite = function (container, callback) {
-  var indexFile = container.metadata['web-index'];
+  var indexFile = container.metadata['web-index'], errorFile = container.metadata['web-error'],
+    metadata = {
+      'web-index': indexFile,
+      'web-error': errorFile
+    };
 
-  this.removeContainerMetadata(container, {'web-index': indexFile}, callback);
+  this.removeContainerMetadata(container, metadata, callback);
 };
 
 /**

--- a/lib/pkgcloud/rackspace/storage/container.js
+++ b/lib/pkgcloud/rackspace/storage/container.js
@@ -42,8 +42,8 @@ Container.prototype.updateCdn = function (options, callback) {
   this.client.updateCdnContainer(this, options, callback);
 };
 
-Container.prototype.setStaticWebsiteIndexPage = function (options, callback) {
-  this.client.setStaticWebsiteIndexPage(this, options, callback);
+Container.prototype.setStaticWebsite = function (options, callback) {
+  this.client.setStaticWebsite(this, options, callback);
 };
 
 Container.prototype.removeStaticWebsite = function (callback) {

--- a/test/rackspace/storage/container-test.js
+++ b/test/rackspace/storage/container-test.js
@@ -442,7 +442,7 @@ describe('pkgcloud/rackspace/storage/containers', function () {
       });
     });
 
-    it('getContainer and set static website index page ', function (done) {
+    it('getContainer and set static website index page and error page ', function (done) {
 
       if (mock) {
         server
@@ -464,6 +464,7 @@ describe('pkgcloud/rackspace/storage/containers', function () {
             'x-container-object-count': '144',
             'x-container-meta-awesome': 'Tue Jun 04 2013 07:58:52 GMT-0700 (PDT)',
             'x-container-meta-web-index': 'index.htm',
+            'x-container-meta-web-error': 'error.htm',
             'x-timestamp': '1368837729.84945',
             'x-container-meta-foo': 'baz',
             'x-container-bytes-used': '134015617',
@@ -478,6 +479,7 @@ describe('pkgcloud/rackspace/storage/containers', function () {
             'x-cdn-ssl-uri': 'https://c98c1215ec09a78cd287-edfcb31ae70ea7c07367728d50539bc7.ssl.cf1.rackcdn.com',
             'x-ttl': '186400',
             'x-container-meta-web-index': 'index.htm',
+            'x-container-meta-web-error': 'error.htm',
             'x-log-retention': 'True',
             'content-type': 'text/html; charset=UTF-8',
             'x-cdn-streaming-uri': 'http://e5addf7be8783adf8c6d-edfcb31ae70ea7c07367728d50539bc7.r63.stream.cf1.rackcdn.com',
@@ -493,13 +495,15 @@ describe('pkgcloud/rackspace/storage/containers', function () {
         container.should.be.instanceof(Container);
 
         (container.metadata['web-index'] == undefined).should.be.true;
+        (container.metadata['web-error'] == undefined).should.be.true;
 
-        container.setStaticWebsiteIndexPage({indexFile: 'index.htm'}, function (err, container) {
+        container.setStaticWebsite({indexFile: 'index.htm', errorFile: 'error.htm'}, function (err, container) {
           should.not.exist(err);
           should.exist(container);
           container.should.be.instanceof(Container);
 
           container.metadata['web-index'].should.equal('index.htm');
+          container.metadata['web-error'].should.equal('error.htm');
 
           server && server.done();
           done();
@@ -516,6 +520,7 @@ describe('pkgcloud/rackspace/storage/containers', function () {
             'x-container-object-count': '144',
             'x-container-meta-awesome': 'Tue Jun 04 2013 07:58:52 GMT-0700 (PDT)',
             'x-container-meta-web-index': 'index.htm',
+            'x-container-meta-web-error': 'error.htm',
             'x-timestamp': '1368837729.84945',
             'x-container-meta-foo': 'baz',
             'x-container-bytes-used': '134015617',
@@ -557,6 +562,7 @@ describe('pkgcloud/rackspace/storage/containers', function () {
         container.should.be.instanceof(Container);
 
         container.metadata['web-index'].should.equal('index.htm');
+        container.metadata['web-error'].should.equal('error.htm');
 
         container.removeStaticWebsite(function (err, container) {
           should.not.exist(err);
@@ -564,6 +570,7 @@ describe('pkgcloud/rackspace/storage/containers', function () {
           container.should.be.instanceof(Container);
 
           (container.metadata['web-index'] == undefined).should.be.true;
+          (container.metadata['web-error'] == undefined).should.be.true;
 
           server && server.done();
           done();


### PR DESCRIPTION
This pull request adds the ability to enable CDN container to serve static web pages and to set the index page of the static website.
[Rackspace Create Static Website](http://docs.rackspace.com/files/api/v1/cf-devguide/content/Create_Static_Website-dle4000.html)

```
  container.setStaticWebsiteIndexPage({ indexFile: 'index.html' }, function(err, container) {
    if (err) {
      // handle error
    }

    console.log(container.staticWebsiteIndexPage);
  });
});
```
