### PR TITLE
Options parameter in files.getFiles() is now optional

### DIFF
--- a/lib/pkgcloud/openstack/storage/client/files.js
+++ b/lib/pkgcloud/openstack/storage/client/files.js
@@ -244,6 +244,8 @@ exports.getFiles = function (container, options, callback) {
   if (typeof options === 'function') {
     callback = options;
     options = {};
+  } else if (!options) {
+    options = {};
   }
 
   // If limit is not specified, or it is <=10k, just make a single request


### PR DESCRIPTION
In spec, options parameter appears to be optional (https://github.com/pkgcloud/pkgcloud/blob/master/docs/providers/rackspace/storage.md#clientgetfilescontainer-options-functionerr-files--), however if null is passed, the method generates "TypeError: Cannot read property 'limit' of null".
