### PR TITLE
Since HP is supported in pkgcloud, adding to the keywords in package.jso...

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,10 @@
     "iriscouch",
     "mongohq",
     "openstack",
-    "redistogo"
+    "redistogo",
+    "hpcloud",
+    "hp",
+    "helion"
   ],
   "dependencies": {
     "async": "0.9.x",


### PR DESCRIPTION
Adding to the keywords to improve those looking to use pkgcloud with HP and finding this option.
