### PR TITLE
Added additional query parameters to getFiles

### DIFF
--- a/lib/pkgcloud/openstack/storage/client/files.js
+++ b/lib/pkgcloud/openstack/storage/client/files.js
@@ -289,35 +289,15 @@ exports._getFiles = function (container, options, callback) {
       self = this;
 
   var getFilesOpts = {
-    path: containerName,
-    qs: {
-      format: 'json'
+      path: containerName,
+      qs: _.extend({
+          format: 'json'
+      }, _.pick(options, ['limit', 'marker', 'prefix', 'path', 'delimiter']))
+    };
+
+    if (options.endMarker) {
+      getFilesOpts.qs.end_marker = options.endMarker;
     }
-  };
-
-  if (options.limit) {
-    getFilesOpts.qs.limit = options.limit;
-  }
-
-  if (options.marker) {
-    getFilesOpts.qs.marker = options.marker;
-  }
-
-  if (options.end_marker) {
-    getFilesOpts.qs.end_marker = options.end_marker;
-  }
-
-  if (options.prefix) {
-    getFilesOpts.qs.prefix  = options.prefix;
-  }
-
-  if (options.path) {
-    getFilesOpts.qs.path  = options.path;
-  }
-
-  if (options.delimiter) {
-    getFilesOpts.qs.delimiter  = options.delimiter;
-  }
 
   this._request(getFilesOpts, function (err, body) {
 


### PR DESCRIPTION
The OpenStack client getFiles method was missing a few of the query parameters which the OpenStack API supports. These include end_marker, prefix, path and delimiter. The last three of which are necessary if you want to restrict which files are retrieved when listing files in a container.
