### PR TITLE
[WIP] Add support for getting config from environment variables

### DIFF
--- a/lib/pkgcloud/amazon/index.js
+++ b/lib/pkgcloud/amazon/index.js
@@ -7,3 +7,19 @@
 
 exports.compute = require('./compute');
 exports.storage = require('./storage');
+
+var ENV_PREFIX = 'PKGCLOUD_AMAZON_';
+
+exports.getConfig = function () {
+  var config = {
+    provider: 'amazon',
+    keyId: process.env[ENV_PREFIX + 'KEY_ID'],
+    key: process.env[ENV_PREFIX + 'KEY']
+  };
+
+  if (process.env[ENV_PREFIX + 'REGION']) {
+    config.region = process.env[ENV_PREFIX + 'REGION'];
+  }
+
+  return config;
+};

--- a/lib/pkgcloud/azure/index.js
+++ b/lib/pkgcloud/azure/index.js
@@ -8,3 +8,35 @@
 exports.compute = require('./compute');
 exports.storage = require('./storage');
 exports.database = require('./database');
+
+var ENV_PREFIX = 'PKGCLOUD_AZURE_';
+
+exports.getConfig = function () {
+  var config = {
+    provider: 'azure'
+  };
+
+  // Compute Options
+  if (process.env[ENV_PREFIX + 'KEY']) {
+    config.key = process.env[ENV_PREFIX + 'KEY'];
+  }
+
+  if (process.env[ENV_PREFIX + 'CERT']) {
+    config.cert = process.env[ENV_PREFIX + 'CERT'];
+  }
+
+  if (process.env[ENV_PREFIX + 'SUBSCRIPTION_ID']) {
+    config.subscriptionId = process.env[ENV_PREFIX + 'SUBSCRIPTION_ID'];
+  }
+
+  // Storage Options
+  if (process.env[ENV_PREFIX + 'STORAGE_ACCOUNT']) {
+    config.storageAccount = process.env[ENV_PREFIX + 'STORAGE_ACCOUNT'];
+  }
+
+  if (process.env[ENV_PREFIX + 'STORAGE_ACCESS_KEY']) {
+    config.storageAccessKey = process.env[ENV_PREFIX + 'STORAGE_ACCESS_KEY'];
+  }
+
+  return config;
+};

--- a/lib/pkgcloud/digitalocean/index.js
+++ b/lib/pkgcloud/digitalocean/index.js
@@ -6,3 +6,19 @@
  */
 
 exports.compute = require('./compute');
+
+var ENV_PREFIX = 'PKGCLOUD_DIGITALOCEAN_';
+
+exports.getConfig = function () {
+  var config = {
+    provider: 'digitalocean',
+    clientId: process.env[ENV_PREFIX + 'CLIENTID'],
+    apiKey: process.env[ENV_PREFIX + 'APIKEY']
+  };
+
+  if (process.env[ENV_PREFIX + 'REGION']) {
+    config.region = process.env[ENV_PREFIX + 'REGION'];
+  }
+
+  return config;
+};

--- a/lib/pkgcloud/hp/index.js
+++ b/lib/pkgcloud/hp/index.js
@@ -9,3 +9,26 @@
 exports.storage = require('./storage');
 exports.compute = require('./compute');
 exports.network = require('./network');
+
+var ENV_PREFIX = 'PKGCLOUD_HP_';
+
+exports.getConfig = function () {
+  var config = {
+    provider: 'hp',
+    username: process.env[ENV_PREFIX + 'USERNAME'],
+    authUrl: process.env[ENV_PREFIX + 'AUTH_URL']
+  };
+
+  if (process.env[ENV_PREFIX + 'APIKEY']) {
+    config.apiKey = process.env[ENV_PREFIX + 'APIKEY'];
+  }
+  else if (process.env[ENV_PREFIX + 'PASSWORD']) {
+    config.password = process.env[ENV_PREFIX + 'PASSWORD'];
+  }
+
+  if (process.env[ENV_PREFIX + 'REGION']) {
+    config.region = process.env[ENV_PREFIX + 'REGION'];
+  }
+
+  return config;
+};

--- a/lib/pkgcloud/openstack/index.js
+++ b/lib/pkgcloud/openstack/index.js
@@ -10,3 +10,20 @@ exports.identity = require('./identity');
 exports.orchestration = require('./orchestration');
 exports.network = require('./network');
 exports.storage = require('./storage');
+
+var ENV_PREFIX = 'PKGCLOUD_OPENSTACK_';
+
+exports.getConfig = function () {
+  var config = {
+    provider: 'openstack',
+    username: process.env[ENV_PREFIX + 'USERNAME'],
+    password: process.env[ENV_PREFIX + 'PASSWORD'],
+    authUrl: process.env[ENV_PREFIX + 'AUTH_URL']
+  };
+
+  if (process.env[ENV_PREFIX + 'REGION']) {
+    config.region = process.env[ENV_PREFIX + 'REGION'];
+  }
+
+  return config;
+};

--- a/lib/pkgcloud/rackspace/index.js
+++ b/lib/pkgcloud/rackspace/index.js
@@ -11,3 +11,33 @@ exports.database = require('./database');
 exports.dns = require('./dns');
 exports.loadbalancer = require('./loadbalancer');
 exports.storage = require('./storage');
+
+var ENV_PREFIX = 'PKGCLOUD_RACKSPACE_';
+
+exports.getConfig = function() {
+  var config = {
+    provider: 'rackspace',
+    username: process.env[ENV_PREFIX + 'USERNAME']
+  };
+
+  if (process.env[ENV_PREFIX + 'APIKEY']) {
+    config.apiKey = process.env[ENV_PREFIX + 'APIKEY'];
+  }
+  else if (process.env[ENV_PREFIX + 'PASSWORD']) {
+    config.password = process.env[ENV_PREFIX + 'PASSWORD'];
+  }
+
+  if (process.env[ENV_PREFIX + 'REGION']) {
+    config.region = process.env[ENV_PREFIX + 'REGION'];
+  }
+
+  if (process.env[ENV_PREFIX + 'USE_INTERNAL']) {
+    config.useInternal = true;
+  }
+
+  if (process.env[ENV_PREFIX + 'AUTH_URL']) {
+    config.authUrl = process.env[ENV_PREFIX + 'AUTH_URL'];
+  }
+
+  return config;
+};


### PR DESCRIPTION
I've been looking at ways to make pkgcloud easier to integrate, and one of the options is using environment variables.

I've taken a first pass at one idea, using a per-provider prefix to get the values from the environment. Here's a contrived example:

```
$ PKGCLOUD_RACKSPACE_USERNAME=myusername PKGCLOUD_RACKSPACE_APIKEY=1234asdf  \
  PKGCLOUD_RACKSPACE_REGION=iad node my-app.js
```

Usage in your application would be like so:

``` javascript
var pkgcloud = require('pkgcloud');

var computeClient = pkgcloud.compute.createClient(pkgcloud.providers.rackspace.getConfig());
```

I wanted to open the PR to start discussion...
