### PR TITLE
default header check

### DIFF
--- a/lib/pkgcloud/openstack/client.js
+++ b/lib/pkgcloud/openstack/client.js
@@ -52,6 +52,10 @@ var Client = exports.Client = function (options) {
   });
 
   this.before.push(function (req) {
+    if (req.headers['Content-Type'] && req.headers['Content-Type'] !== 'application/json') {
+      req.json = false;
+      return;
+    }
     req.json = true;
     if (typeof req.body !== 'undefined') {
       req.headers['Content-Type'] = 'application/json';


### PR DESCRIPTION
Just checking if the `content-type` header was already set, and doesn't overwrite it in that case.
