### PR TITLE
response event on download

### DIFF
--- a/lib/pkgcloud/openstack/client.js
+++ b/lib/pkgcloud/openstack/client.js
@@ -200,6 +200,9 @@ Client.prototype._request = function (options, callback) {
         proxyStream.pipe(apiStream);
       }
       else if (options.download) {
+        apiStream.on('response', function (response) {
+          proxyStream.emit('response', response);
+        });
         apiStream.pipe(proxyStream);
       }
 


### PR DESCRIPTION
This was added to be able not to wait until the file is completely loaded into memory (what happens if you use a callback). That response event will be fired when only the headers of the file are loaded, so I can do something when that happens.
