### PR TITLE
subdir for _getFiles

### DIFF
--- a/lib/pkgcloud/openstack/storage/client/files.js
+++ b/lib/pkgcloud/openstack/storage/client/files.js
@@ -322,15 +322,6 @@ exports._getFiles = function (container, options, callback) {
 
     return callback(null, body.map(function (file) {
       file.container = container;
-      if (file.subdir) {
-        return {
-          "isDir": true,
-          "name": file.subdir.slice(-1) === '/' ?
-            file.subdir.substring(0, file.subdir.length - 1) :
-            file.subdir,
-          "container": file.container
-        };
-      }
       return new self.models.File(self, file);
     }));
   });

--- a/lib/pkgcloud/openstack/storage/file.js
+++ b/lib/pkgcloud/openstack/storage/file.js
@@ -44,6 +44,12 @@ File.prototype._setProperties = function (details) {
   this.metadata = {};
   this.container = details.container || null;
   this.name = details.name || null;
+  this.isDir = !!details.subdir;
+  if (this.isDir) {
+    this.name = this.name.slice(-1) === '/' ?
+      this.name.substring(0, this.name.length - 1) :
+      this.name;
+  }
   this.etag = details.etag || details.hash || null;
   this.contentType = details['content-type'] || details['content_type'] || null;
 


### PR DESCRIPTION
When getting the files of a container, the subdirectories are listed as files with all fields as null.
This fix that, returning an object specifically for folders.
