### PR TITLE
[openstack] [compute] Server toJSON fix

### DIFF
--- a/lib/pkgcloud/openstack/compute/server.js
+++ b/lib/pkgcloud/openstack/compute/server.js
@@ -136,7 +136,7 @@ Server.prototype.getAddresses = function (type, callback) {
 
 Server.prototype.toJSON = function() {
   return _.pick(this, ['id', 'name', 'status', 'hostId', 'adminPass', 'addresses',
-    'links', 'key_name', 'image', 'flavor', 'user_id', 'tenant_id', 'progress',
+    'links', 'key_name', 'imageId', 'flavorId', 'user_id', 'tenant_id', 'progress',
     'OS-EXT-STS:task_state', 'OS-EXT-STS:vm_state', 'OS-EXT-STS:power_state',
     'OS-DCF:diskConfig', 'accessIPv4', 'accessIPv6', 'config_drive', 'metadata',
     'created', 'updated']);


### PR DESCRIPTION
[openstack] [compute] fixes Server toJSON mistakenly returning 'flavor' and 'image' instead of 'flavorId' and 'imageId'
