### PR TITLE
Set initial metadata on file upload in gcloud writeStream

### DIFF
--- a/lib/pkgcloud/google/storage/client/files.js
+++ b/lib/pkgcloud/google/storage/client/files.js
@@ -40,6 +40,7 @@ exports.upload = function (options) {
   var self = this,
     bucket = this._getBucket(options),
     file = this._getFile(bucket, options);
+    metadata = options.metadata || {};
 
   // check for deprecated calling with a callback
   if (typeof arguments[arguments.length - 1] === 'function') {
@@ -47,7 +48,7 @@ exports.upload = function (options) {
   }
 
   var proxyStream = through(),
-    writableStream = file.createWriteStream();
+    writableStream = file.createWriteStream(metadata);
 
   // we need a proxy stream so we can always return a file model
   // via the 'success' event


### PR DESCRIPTION
"this._getFile(bucket, options) -> bucket.file(filename)" created
without initial metadata.