### PR TITLE
Improved directory support for Openstack getFiles

### DIFF
--- a/lib/pkgcloud/openstack/storage/file.js
+++ b/lib/pkgcloud/openstack/storage/file.js
@@ -43,7 +43,7 @@ File.prototype._setProperties = function (details) {
 
   this.metadata = {};
   this.container = details.container || null;
-  this.name = details.name || null;
+  this.name = details.name || details.subdir || null;
   this.etag = details.etag || details.hash || null;
   this.contentType = details['content-type'] || details['content_type'] || null;
 

--- a/lib/pkgcloud/openstack/storage/file.js
+++ b/lib/pkgcloud/openstack/storage/file.js
@@ -45,7 +45,12 @@ File.prototype._setProperties = function (details) {
   this.container = details.container || null;
   this.name = details.name || details.subdir || null;
   this.etag = details.etag || details.hash || null;
-  this.contentType = details['content-type'] || details['content_type'] || null;
+
+  if (details.subdir) {
+    this.contentType = 'application/directory';
+  } else {
+    this.contentType = details['content-type'] || details['content_type'] || null;
+  }
 
   this.lastModified = details['last-modified']
     ? new Date(details['last-modified'])


### PR DESCRIPTION
Directories now have names and a content type of 'application/directory'.