### PR TITLE
Add support for prepending a custom user agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,21 @@ Currently there are six service types which are handled by pkgcloud:
 
 In our [Roadmap](#roadmap), we plan to add support for more services, such as Queueing, Monitoring, and more. Additionally, we plan to implement more providers for the *beta* services, thus moving them out of *beta*.
 
+### User Agent
+
+By default, all pkgcloud HTTP requests will have a user agent with the library and version: `nodejs-pkgcloud/x.y.z` where `x.y.z` is the current version.
+
+You can get this from a client at any time by calling `client.getUserAgent();`. Some providers may have an additional suffix as a function of the underlying HTTP stacks.
+
+You can also set a custom User Agent prefix:
+
+```javascript
+client.setCustomUserAgent('my-app/1.2.3');
+
+// returns "my-app/1.2.3 nodejs-pkgcloud/1.1.0"
+client.getUserAgent();
+```
+
 <a name="basic-apis"></a>
 ### Basic APIs for pkgcloud
 

--- a/lib/pkgcloud/amazon/client.js
+++ b/lib/pkgcloud/amazon/client.js
@@ -7,7 +7,6 @@
 
 var util = require('util'),
     AWS = require('aws-sdk'),
-    pkgcloud = require('../../../../pkgcloud'),
     base = require('../core/base');
 
 var userAgent = AWS.util.userAgent();

--- a/lib/pkgcloud/amazon/client.js
+++ b/lib/pkgcloud/amazon/client.js
@@ -46,7 +46,7 @@ var Client = exports.Client = function (options) {
     });
   }
 
-  this.userAgent = util.format('nodejs-pkgcloud/%s %s', pkgcloud.version, userAgent);
+  this.userAgent = util.format('%s %s', self.getUserAgent(), userAgent);
 
   // Setup a custom user agent for pkgcloud
   AWS.util.userAgent = function () {

--- a/lib/pkgcloud/core/base/client.js
+++ b/lib/pkgcloud/core/base/client.js
@@ -33,6 +33,10 @@ util.inherits(Client, events.EventEmitter2);
  * @description allows the caller to specify a custom prefix for the HTTP UserAgent
  * for all queries generated during the lifetime of the client.
  *
+ * Valid user agents should come in the form of app-name/version, for example:
+ *
+ * client.setCustomUserAgent("my-app/1.2.3");
+ *
  * @param {String}          userAgent   the new userAgent to be prefixed
  */
 Client.prototype.setCustomUserAgent = function (userAgent) {

--- a/lib/pkgcloud/core/base/client.js
+++ b/lib/pkgcloud/core/base/client.js
@@ -28,6 +28,30 @@ var Client = exports.Client = function (options) {
 util.inherits(Client, events.EventEmitter2);
 
 /**
+ * Client.setCustomUserAgent
+ *
+ * @description allows the caller to specify a custom prefix for the HTTP UserAgent
+ * for all queries generated during the lifetime of the client.
+ *
+ * @param {String}          userAgent   the new userAgent to be prefixed
+ */
+Client.prototype.setCustomUserAgent = function (userAgent) {
+  this._customUserAgent = userAgent;
+};
+
+/**
+ * Client.getUserAgent
+ *
+ * @description gets the full UserAgent for the current client
+ *
+ * @returns {string}
+ */
+Client.prototype.getUserAgent = function() {
+  return util.format('%snodejs-pkgcloud/%s', this._customUserAgent ?
+    this._customUserAgent + ' ' : '', pkgcloud.version);
+};
+
+/**
  * Client._request
  *
  * @description is the global request handler for a pkgcloud client request.
@@ -103,7 +127,7 @@ Client.prototype._request = function (options, callback) {
     delete opts.signingUrl;
 
     // Set our User Agent
-    opts.headers['User-Agent'] = util.format('nodejs-pkgcloud/%s', pkgcloud.version);
+    opts.headers['User-Agent'] = self.getUserAgent();
 
     // If we are missing callback
     if (!callback) {

--- a/test/common/base/client-test.js
+++ b/test/common/base/client-test.js
@@ -6,6 +6,7 @@
 */
 
 var should = require('should'),
+    pkgcloud = require('../../../lib/pkgcloud'),
     Client = new require('../../../lib/pkgcloud/core/base/client').Client;
 
 describe('pkgcloud/core/base/client', function () {
@@ -57,6 +58,12 @@ describe('pkgcloud/core/base/client', function () {
         should.exist(err);
         done();
       });
+    });
+
+    it('custom user agents should work', function () {
+      var cli = new Client();
+      cli.setCustomUserAgent('my-app/1.2.3');
+      cli.getUserAgent().should.equal('my-app/1.2.3 nodejs-pkgcloud/' + pkgcloud.version);
     });
 
     it('the before filters throwing an error without a callback should return the error on the EE', function(done) {

--- a/test/common/base/useragent-test.js
+++ b/test/common/base/useragent-test.js
@@ -1,0 +1,29 @@
+/*
+ * useragent-test.js: Tests for pkgcloud base client useragent
+ *
+ * (C) 2015 Ken Perkins, Rackspace Inc.
+ *
+ */
+
+var should = require('should'),
+  pkgcloud = require('../../../lib/pkgcloud'),
+  Client = new require('../../../lib/pkgcloud/core/base/client').Client;
+
+describe('pkgcloud/core/base/client/useragent', function () {
+  describe('getUserAgent tests', function () {
+    it('should return the default useragent', function () {
+      var cli = new Client();
+
+      cli.getUserAgent().should.equal('nodejs-pkgcloud/' + pkgcloud.version);
+    });
+  });
+
+  describe('setCustomUserAgent tests', function () {
+    it('should allow prefixing a custom useragent', function () {
+      var cli = new Client();
+
+      cli.setCustomUserAgent('my-app/1.2.3');
+      cli.getUserAgent().should.equal('my-app/1.2.3 nodejs-pkgcloud/' + pkgcloud.version);
+    });
+  });
+});

--- a/test/common/base/useragent-test.js
+++ b/test/common/base/useragent-test.js
@@ -5,9 +5,10 @@
  *
  */
 
-var should = require('should'),
-  pkgcloud = require('../../../lib/pkgcloud'),
+var pkgcloud = require('../../../lib/pkgcloud'),
   Client = new require('../../../lib/pkgcloud/core/base/client').Client;
+
+require('should');
 
 describe('pkgcloud/core/base/client/useragent', function () {
   describe('getUserAgent tests', function () {


### PR DESCRIPTION
- part of #394
- This only affects all clients the derive from core/base/client.js
- This is probably 95% of all network traffic
- There are some one-offs that need broader investigation on the correct strategy