### PR TITLE
Allow non strict ssl in Openstack provider

### DIFF
--- a/lib/pkgcloud/openstack/client.js
+++ b/lib/pkgcloud/openstack/client.js
@@ -80,6 +80,9 @@ Client.prototype._getIdentityOptions = function() {
     password: this.config.password
   };
 
+  options.strictSSL = typeof this.config.strictSSL === 'boolean'
+  ? this.config.strictSSL : true;
+
   if (this.config.tenantId) {
     options.tenantId = this.config.tenantId;
   }

--- a/lib/pkgcloud/openstack/context/identity.js
+++ b/lib/pkgcloud/openstack/context/identity.js
@@ -107,6 +107,7 @@ Identity.prototype.authorize = function (options, callback) {
   var authenticationOptions = {
     uri: urlJoin(options.url || self.options.url, self.basePath),
     method: 'POST',
+    strictSSL: options.strictSSL || self.options.strictSSL,
     headers: {
       'User-Agent': util.format('nodejs-pkgcloud/%s', pkgcloud.version),
       'Content-Type': 'application/json',
@@ -188,6 +189,7 @@ Identity.prototype.authorize = function (options, callback) {
     var tenantOptions = {
       uri: endpoint,
       json: true,
+      strictSSL: options.strictSSL || self.options.strictSSL,
       headers: {
         'X-Auth-Token': token,
         'Content-Type': 'application/json',
@@ -269,7 +271,7 @@ Identity.prototype._parseIdentityResponse = function (data) {
   if (!data) {
     throw new Error('missing required arguments!');
   }
-  
+
   if (data.access.token) {
     self.token = data.access.token;
     self.token.expires = new Date(self.token.expires);


### PR DESCRIPTION
When trying to authenticate against an Openstack server with a self-signed certificate, I kept running into 
[Error: UNABLE_TO_VERIFY_LEAF_SIGNATURE] even though I had set the strictSSL flag to false on the config option.
After debugging, it turns out we weren't passing in the strictSSL option down to the authorize method in the Openstack identity type. This PR changes the getIdentityOptions to pass in the flag and also the authorize function to use the flag.