### PR TITLE
storage: google: upload: return metadata in success handler - fixes #400

### DIFF
--- a/lib/pkgcloud/google/storage/client/files.js
+++ b/lib/pkgcloud/google/storage/client/files.js
@@ -51,7 +51,7 @@ exports.upload = function (options) {
 
   // we need a proxy stream so we can always return a file model
   // via the 'success' event
-  writableStream.on('complete', function(file) {
+  writableStream.on('complete', function() {
     proxyStream.emit('success', new storage.File(self, file));
   });
 


### PR DESCRIPTION
Fixes #400 

This was a fail. gcloud updates the original `file` instance with new metadata after a successful operation. I should have passed the original file reference to `new storage.File`, not the argument to `complete`.