### PR TITLE
Cancel openstack's client.download

### DIFF
--- a/lib/pkgcloud/openstack/client.js
+++ b/lib/pkgcloud/openstack/client.js
@@ -199,6 +199,10 @@ Client.prototype._request = function (options, callback) {
         apiStream.abort();
       });
 
+      proxyStream.abort = function () {
+        apiStream.abort();
+      };
+
       if (options.upload) {
 
         // needed for event propagation during proxied auth for streams

--- a/lib/pkgcloud/openstack/client.js
+++ b/lib/pkgcloud/openstack/client.js
@@ -195,6 +195,10 @@ Client.prototype._request = function (options, callback) {
       self.emit('log::trace', 'Creating Authenticated Proxy Request');
       var apiStream = Client.super_.prototype._request.call(self, options, callback);
 
+      proxyStream.on('abort', function () {
+        apiStream.abort();
+      });
+
       if (options.upload) {
 
         // needed for event propagation during proxied auth for streams
@@ -209,6 +213,14 @@ Client.prototype._request = function (options, callback) {
         proxyStream.pipe(apiStream);
       }
       else if (options.download) {
+        apiStream.on('error', function (err) {
+          proxyStream.emit('error', err);
+        });
+
+        apiStream.on('response', function (response) {
+          proxyStream.emit('response', response);
+        });
+
         apiStream.pipe(proxyStream);
       }
 

--- a/lib/pkgcloud/openstack/storage/client/files.js
+++ b/lib/pkgcloud/openstack/storage/client/files.js
@@ -202,7 +202,8 @@ exports.download = function (options, callback) {
   apiStream = this._request({
     container: container,
     path: options.remote,
-    download: true
+    download: true,
+    headers: options.headers
   }, success);
 
   if (inputStream) {


### PR DESCRIPTION
1. Add `abort` on `openstack`'s client.download
1. `openstack`'s file request should able to add header such as `Range`
1. give `response` and `error` event to callback

close #379 also