### PR TITLE
Reassign Nodejitsu copyright to the project contributors.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2011 Nodejitsu Inc. 
+Copyright (C) 2011 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/lib/pkgcloud.js
+++ b/lib/pkgcloud.js
@@ -1,7 +1,7 @@
 /*
  * pkgcloud.js: Top-level include for the pkgcloud module
  *
- * (C) 2011 Nodejitsu Inc.
+ * (C) 2011 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/amazon/client.js
+++ b/lib/pkgcloud/amazon/client.js
@@ -1,7 +1,7 @@
 /*
  * client.js: Base client from which all AWS clients inherit from
  *
- * (C) 2012 Nodejitsu Inc.
+ * (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/amazon/compute/client/flavors.js
+++ b/lib/pkgcloud/amazon/compute/client/flavors.js
@@ -1,7 +1,7 @@
 /*
  * flavors.js: Implementation of AWS Flavors Client.
  *
- * (C) 2012, Nodejitsu Inc.
+ * (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/amazon/compute/client/images.js
+++ b/lib/pkgcloud/amazon/compute/client/images.js
@@ -1,7 +1,7 @@
 /*
  * images.js: Implementation of AWS Images Client.
  *
- * (C) 2012, Nodejitsu Inc.
+ * (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 var pkgcloud = require('../../../../../lib/pkgcloud'),

--- a/lib/pkgcloud/amazon/compute/client/index.js
+++ b/lib/pkgcloud/amazon/compute/client/index.js
@@ -1,7 +1,7 @@
 /*
  * index.js: Compute client for AWS CloudAPI
  *
- * (C) 2012 Nodejitsu Inc.
+ * (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/amazon/compute/client/keys.js
+++ b/lib/pkgcloud/amazon/compute/client/keys.js
@@ -1,7 +1,7 @@
 /*
  * keys.js: Implementation of AWS SSH keys Client.
  *
- * (C) 2012, Nodejitsu Inc.
+ * (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/amazon/compute/client/servers.js
+++ b/lib/pkgcloud/amazon/compute/client/servers.js
@@ -1,7 +1,7 @@
 /*
  * servers.js: Instance methods for working with servers from AWS Cloud
  *
- * (C) 2012 Nodejitsu Inc.
+ * (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 var async = require('async'),
@@ -254,7 +254,7 @@ exports.getServer = function getServer(server, callback) {
         if (err) {
           return callback(err);
         }
-        
+
         callback(null, new compute.Server(self, server));
       });
     }

--- a/lib/pkgcloud/amazon/compute/flavor.js
+++ b/lib/pkgcloud/amazon/compute/flavor.js
@@ -1,7 +1,7 @@
 /*
  * flavor.js: AWS Cloud Package
  *
- * (C) 2012 Nodejitsu Inc.
+ * (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/amazon/compute/image.js
+++ b/lib/pkgcloud/amazon/compute/image.js
@@ -1,7 +1,7 @@
 /*
  * image.js: AWS Cloud
  *
- * (C) 2012 Nodejitsu Inc.
+ * (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/amazon/compute/index.js
+++ b/lib/pkgcloud/amazon/compute/index.js
@@ -1,7 +1,7 @@
 /*
  * index.js: Top-level include for the AWS compute module
  *
- * (C) 2012 Nodejitsu Inc.
+ * (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/amazon/compute/server.js
+++ b/lib/pkgcloud/amazon/compute/server.js
@@ -1,7 +1,7 @@
 /*
  * server.js: AWS Server
  *
- * (C) 2012 Nodejitsu Inc.
+ * (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/amazon/index.js
+++ b/lib/pkgcloud/amazon/index.js
@@ -1,7 +1,7 @@
 /*
  * index.js: Top-level include for the AWS module.
  *
- * (C) 2012 Nodejitsu Inc.
+ * (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/amazon/storage/client/containers.js
+++ b/lib/pkgcloud/amazon/storage/client/containers.js
@@ -1,7 +1,7 @@
 /*
  * containers.js: Instance methods for working with containers from AWS S3
  *
- * (C) 2012 Nodejitsu Inc.
+ * (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/amazon/storage/client/files.js
+++ b/lib/pkgcloud/amazon/storage/client/files.js
@@ -1,7 +1,7 @@
 /*
  * files.js: Instance methods for working with files from AWS S3
  *
- * (C) 2012 Nodejitsu Inc.
+ * (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/amazon/storage/client/index.js
+++ b/lib/pkgcloud/amazon/storage/client/index.js
@@ -1,7 +1,7 @@
 /*
  * client.js: Storage client for AWS S3
  *
- * (C) 2011 Nodejitsu Inc.
+ * (C) 2011 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/amazon/storage/container.js
+++ b/lib/pkgcloud/amazon/storage/container.js
@@ -1,7 +1,7 @@
 /*
  * container.js: AWS S3 Bucket
  *
- * (C) 2012 Nodejitsu Inc.
+ * (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/amazon/storage/file.js
+++ b/lib/pkgcloud/amazon/storage/file.js
@@ -1,7 +1,7 @@
 /*
  * container.js: AWS S3 File
  *
- * (C) 2012 Nodejitsu Inc.
+ * (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/amazon/storage/index.js
+++ b/lib/pkgcloud/amazon/storage/index.js
@@ -1,7 +1,7 @@
 /*
  * index.js: Top-level include for the AWS S3 module
  *
- * (C) 2012 Nodejitsu Inc.
+ * (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/common/auth.js
+++ b/lib/pkgcloud/common/auth.js
@@ -1,7 +1,7 @@
 /*
  * auth.js: Utilities for authenticating with multiple cloud providers
  *
- * (C) 2011-2012 Nodejitsu Inc.
+ * (C) 2011-2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/common/azure-signature.js
+++ b/lib/pkgcloud/common/azure-signature.js
@@ -1,7 +1,7 @@
 /*
  * azure-signature.js: Implementation of authentication for Azure APIs.
  *
- * (C) 2012 Nodejitsu Inc.
+ * (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/common/http-signature.js
+++ b/lib/pkgcloud/common/http-signature.js
@@ -4,7 +4,7 @@
  * Copyright (C) 2011 Joyent, Inc.  All rights reserved.
  * MIT License
  *
- * Modified by Nodejitsu, under MIT
+ * Modified under MIT
  *
  */
 

--- a/lib/pkgcloud/common/index.js
+++ b/lib/pkgcloud/common/index.js
@@ -1,7 +1,7 @@
 /*
  * index.js: Top-level include for the pkgcloud common module.
  *
- * (C) 2011 Nodejitsu Inc.
+ * (C) 2011 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/common/status.js
+++ b/lib/pkgcloud/common/status.js
@@ -1,7 +1,7 @@
 /*
  * status.js: Standardized statuses for different services
  *
- * (C) 2011-2012 Nodejitsu Inc.
+ * (C) 2011-2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/core/base/client.js
+++ b/lib/pkgcloud/core/base/client.js
@@ -1,7 +1,7 @@
 /*
  * client.js: Base client from which all pkgcloud clients inherit from
  *
- * (C) 2013 Nodejitsu Inc.
+ * (C) 2013 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 
@@ -95,7 +95,7 @@ Client.prototype._request = function (options, callback) {
       requestOptions.signingUrl += '?' + qs.stringify(options.qs);
     }
   }
-  
+
   function sendRequest(opts) {
 
     //

--- a/lib/pkgcloud/core/base/index.js
+++ b/lib/pkgcloud/core/base/index.js
@@ -1,7 +1,7 @@
 /*
  * index.js: Top-level include for pkgcloud `base` module from which all pkgcloud objects inherit.
  *
- * (C) 2011 Nodejitsu Inc.
+ * (C) 2011 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/core/base/model.js
+++ b/lib/pkgcloud/core/base/model.js
@@ -1,7 +1,7 @@
 /*
  * model.js: Base model from which all pkgcloud models inherit from
  *
- * (C) 2011 Nodejitsu Inc.
+ * (C) 2011 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/core/compute/flavor.js
+++ b/lib/pkgcloud/core/compute/flavor.js
@@ -1,7 +1,7 @@
 /*
  * flavor.js: Base flavor from which all pkgcloud flavors inherit from
  *
- * (C) 2011 Nodejitsu Inc.
+ * (C) 2011 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/core/compute/image.js
+++ b/lib/pkgcloud/core/compute/image.js
@@ -1,7 +1,7 @@
 /*
  * image.js: Base image from which all pkgcloud images inherit from
  *
- * (C) 2011 Nodejitsu Inc.
+ * (C) 2011 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/core/compute/index.js
+++ b/lib/pkgcloud/core/compute/index.js
@@ -1,7 +1,7 @@
 /*
  * index.js: Top-level include from which all pkgcloud compute models inherit.
  *
- * (C) 2011 Nodejitsu Inc.
+ * (C) 2011 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/core/compute/server.js
+++ b/lib/pkgcloud/core/compute/server.js
@@ -1,7 +1,7 @@
 /*
  * server.js: Base server from which all pkgcloud servers inherit from
  *
- * (C) 2011 Nodejitsu Inc.
+ * (C) 2011 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/core/storage/container.js
+++ b/lib/pkgcloud/core/storage/container.js
@@ -1,7 +1,7 @@
 /*
  * container.js: Base container from which all pkgcloud containers inherit from
  *
- * (C) 2010 Nodejitsu Inc.
+ * (C) 2010 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/core/storage/file.js
+++ b/lib/pkgcloud/core/storage/file.js
@@ -1,7 +1,7 @@
 /*
  * file.js: Base container from which all pkgcloud files inherit from
  *
- * (C) 2010 Nodejitsu Inc.
+ * (C) 2010 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/core/storage/index.js
+++ b/lib/pkgcloud/core/storage/index.js
@@ -1,7 +1,7 @@
 /*
  * index.js: Top-level include from which all pkgcloud storage models inherit.
  *
- * (C) 2011 Nodejitsu Inc.
+ * (C) 2011 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/digitalocean/client.js
+++ b/lib/pkgcloud/digitalocean/client.js
@@ -1,7 +1,7 @@
 /*
  * client.js: Base client from which all Joyent clients inherit from
  *
- * (C) 2012 Nodejitsu Inc.
+ * (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 
@@ -25,7 +25,7 @@ var Client = exports.Client = function (opts) {
   this.provider = 'digitalocean';
   this.protocol = opts.protocol || 'https://';
   this.serversUrl = opts.serversUrl;
-  
+
   if (!this.before) {
     this.before = [];
   }

--- a/lib/pkgcloud/digitalocean/compute/client/flavors.js
+++ b/lib/pkgcloud/digitalocean/compute/client/flavors.js
@@ -1,7 +1,7 @@
 /*
  * flavors.js: Implementation of DigitalOcean Flavors Client.
  *
- * (C) 2012, Nodejitsu Inc.
+ * (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 
@@ -24,10 +24,10 @@ exports.getFlavors = function getFlavors(callback) {
     if (err || !body.sizes) {
       return callback(err || new Error('No flavors provided.'));
     }
-    
+
     callback(null, body.sizes.map(function (result) {
       return new compute.Flavor(self, result);
-    }), res);    
+    }), res);
   });
 };
 
@@ -54,7 +54,7 @@ exports.getFlavor = function getFlavor(flavor, callback) {
     var flavor = body.sizes.filter(function (flavor) {
       return flavor.id == flavorId;
     })[0];
-    
+
     return !flavor
       ? callback(new Error('No flavor found with id: ' + flavorId))
       : callback(null, new compute.Flavor(self, flavor));

--- a/lib/pkgcloud/digitalocean/compute/client/images.js
+++ b/lib/pkgcloud/digitalocean/compute/client/images.js
@@ -1,7 +1,7 @@
 /*
  * images.js: Implementation of DigitalOcean Images Client.
  *
- * (C) 2012, Nodejitsu Inc.
+ * (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 var pkgcloud = require('../../../../../lib/pkgcloud'),
@@ -41,7 +41,7 @@ exports.getImages = function getImages(callback) {
 //
 exports.getImage = function getImage(image, callback) {
   var imageId = image instanceof base.Image ? image.id : image,
-      self    = this;      
+      self    = this;
 
   return this._request({
     path: '/images/' + imageId

--- a/lib/pkgcloud/digitalocean/compute/client/index.js
+++ b/lib/pkgcloud/digitalocean/compute/client/index.js
@@ -1,7 +1,7 @@
 /*
  * index.js: Compute client for DigitalOcean API
  *
- * (C) 2012 Nodejitsu Inc.
+ * (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/digitalocean/compute/client/keys.js
+++ b/lib/pkgcloud/digitalocean/compute/client/keys.js
@@ -1,7 +1,7 @@
 /*
  * keys.js: Implementation of DigitalOcean SSH keys Client.
  *
- * (C) 2012, Nodejitsu Inc.
+ * (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/digitalocean/compute/client/servers.js
+++ b/lib/pkgcloud/digitalocean/compute/client/servers.js
@@ -1,7 +1,7 @@
 /*
  * servers.js: Instance methods for working with servers from DigitalOcean
  *
- * (C) 2012 Nodejitsu Inc.
+ * (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 var base     = require('../../../core/compute'),

--- a/lib/pkgcloud/digitalocean/compute/flavor.js
+++ b/lib/pkgcloud/digitalocean/compute/flavor.js
@@ -1,7 +1,7 @@
 /*
  * flavor.js: DigitalOcean Server "Size"
  *
- * (C) 2012 Nodejitsu Inc.
+ * (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 
@@ -19,7 +19,7 @@ Flavor.prototype._setProperties = function (details) {
   this.name = details.name;
   this.ram  = details.memory;
   this.disk = details.disk;
-  
+
   //
   // DigitalOcean specific
   //

--- a/lib/pkgcloud/digitalocean/compute/image.js
+++ b/lib/pkgcloud/digitalocean/compute/image.js
@@ -1,7 +1,7 @@
 /*
  * image.js: DigitalOcean Image
  *
- * (C) 2012 Nodejitsu Inc.
+ * (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/digitalocean/compute/index.js
+++ b/lib/pkgcloud/digitalocean/compute/index.js
@@ -1,7 +1,7 @@
 /*
  * index.js: Top-level include for the DigitalOcean compute module
  *
- * (C) 2012 Nodejitsu Inc.
+ * (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/digitalocean/compute/server.js
+++ b/lib/pkgcloud/digitalocean/compute/server.js
@@ -1,7 +1,7 @@
 /*
  * server.js: DigitalOcean Server
  *
- * (C) 2013 Nodejitsu Inc.
+ * (C) 2013 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/digitalocean/index.js
+++ b/lib/pkgcloud/digitalocean/index.js
@@ -1,7 +1,7 @@
 /*
  * index.js: Top-level include for the DigitalOcean module.
  *
- * (C) 2013 Nodejitsu Inc.
+ * (C) 2013 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/google/client.js
+++ b/lib/pkgcloud/google/client.js
@@ -1,7 +1,7 @@
 /*
  * client.js: Base client from which all Google Cloud Storage clients inherit from
  *
- * (C) 2012 Nodejitsu Inc.
+ * (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/google/index.js
+++ b/lib/pkgcloud/google/index.js
@@ -1,7 +1,7 @@
 /*
  * index.js: Top-level include for the Google Cloud Storage module.
  *
- * (C) 2012 Nodejitsu Inc.
+ * (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/google/storage/client/containers.js
+++ b/lib/pkgcloud/google/storage/client/containers.js
@@ -1,7 +1,7 @@
 /*
  * containers.js: Instance methods for working with containers from Google Cloud Storage
  *
- * (C) 2012 Nodejitsu Inc.
+ * (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/google/storage/client/files.js
+++ b/lib/pkgcloud/google/storage/client/files.js
@@ -1,7 +1,7 @@
 /*
  * files.js: Instance methods for working with files from Google Cloud Storage
  *
- * (C) 2012 Nodejitsu Inc.
+ * (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/google/storage/client/index.js
+++ b/lib/pkgcloud/google/storage/client/index.js
@@ -1,7 +1,7 @@
 /*
  * client.js: Storage client for Google Cloud Storage
  *
- * (C) 2011 Nodejitsu Inc.
+ * (C) 2011 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/google/storage/container.js
+++ b/lib/pkgcloud/google/storage/container.js
@@ -1,7 +1,7 @@
 /*
  * container.js: Google Cloud Storage Bucket
  *
- * (C) 2012 Nodejitsu Inc.
+ * (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/google/storage/file.js
+++ b/lib/pkgcloud/google/storage/file.js
@@ -1,7 +1,7 @@
 /*
  * container.js: Google Cloud Storage File
  *
- * (C) 2012 Nodejitsu Inc.
+ * (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/google/storage/index.js
+++ b/lib/pkgcloud/google/storage/index.js
@@ -1,7 +1,7 @@
 /*
  * index.js: Top-level include for the Google Cloud Storage module
  *
- * (C) 2012 Nodejitsu Inc.
+ * (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/iriscouch/database/client/index.js
+++ b/lib/pkgcloud/iriscouch/database/client/index.js
@@ -1,7 +1,7 @@
 /*
  * client.js: Database client for Iriscouch Cloud Databases
  *
- * (C) 2011 Nodejitsu Inc.
+ * (C) 2011 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/iriscouch/database/index.js
+++ b/lib/pkgcloud/iriscouch/database/index.js
@@ -1,7 +1,7 @@
 /*
  * index.js: Top-level include for the Iriscouch database module
  *
- * (C) 2011 Nodejitsu Inc.
+ * (C) 2011 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/iriscouch/index.js
+++ b/lib/pkgcloud/iriscouch/index.js
@@ -1,7 +1,7 @@
 /*
  * index.js: Top-level include for the iriscouch module.
  *
- * (C) 2011 Nodejitsu Inc.
+ * (C) 2011 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/joyent/client.js
+++ b/lib/pkgcloud/joyent/client.js
@@ -1,7 +1,7 @@
 /*
  * client.js: Base client from which all Joyent clients inherit from
  *
- * (C) 2012 Nodejitsu Inc.
+ * (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/joyent/compute/client/flavors.js
+++ b/lib/pkgcloud/joyent/compute/client/flavors.js
@@ -1,7 +1,7 @@
 /*
  * flavors.js: Implementation of Joyent Flavors Client.
  *
- * (C) 2012, Nodejitsu Inc.
+ * (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/joyent/compute/client/images.js
+++ b/lib/pkgcloud/joyent/compute/client/images.js
@@ -1,7 +1,7 @@
 /*
  * images.js: Implementation of Joyent Images Client.
  *
- * (C) 2012, Nodejitsu Inc.
+ * (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 var pkgcloud = require('../../../../../lib/pkgcloud'),

--- a/lib/pkgcloud/joyent/compute/client/index.js
+++ b/lib/pkgcloud/joyent/compute/client/index.js
@@ -1,7 +1,7 @@
 /*
  * index.js: Compute client for Joyent CloudAPI
  *
- * (C) 2012 Nodejitsu Inc.
+ * (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/joyent/compute/client/keys.js
+++ b/lib/pkgcloud/joyent/compute/client/keys.js
@@ -1,7 +1,7 @@
 /*
  * keys.js: Implementation of Joyent SSH keys Client.
  *
- * (C) 2012, Nodejitsu Inc.
+ * (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/joyent/compute/client/servers.js
+++ b/lib/pkgcloud/joyent/compute/client/servers.js
@@ -1,7 +1,7 @@
 /*
  * servers.js: Instance methods for working with servers from Joyent Cloud
  *
- * (C) 2012 Nodejitsu Inc.
+ * (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 var base     = require('../../../core/compute'),

--- a/lib/pkgcloud/joyent/compute/flavor.js
+++ b/lib/pkgcloud/joyent/compute/flavor.js
@@ -1,7 +1,7 @@
 /*
  * flavor.js: Joyent Cloud Package
  *
- * (C) 2012 Nodejitsu Inc.
+ * (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/joyent/compute/image.js
+++ b/lib/pkgcloud/joyent/compute/image.js
@@ -1,7 +1,7 @@
 /*
  * image.js: Joyent Cloud DataSet
  *
- * (C) 2012 Nodejitsu Inc.
+ * (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/joyent/compute/index.js
+++ b/lib/pkgcloud/joyent/compute/index.js
@@ -1,7 +1,7 @@
 /*
  * index.js: Top-level include for the Joyent compute module
  *
- * (C) 2012 Nodejitsu Inc.
+ * (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/joyent/compute/server.js
+++ b/lib/pkgcloud/joyent/compute/server.js
@@ -1,7 +1,7 @@
 /*
  * server.js: Joyent Cloud Machine
  *
- * (C) 2012 Nodejitsu Inc.
+ * (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/joyent/index.js
+++ b/lib/pkgcloud/joyent/index.js
@@ -1,7 +1,7 @@
 /*
  * index.js: Top-level include for the Joyent module.
  *
- * (C) 2012 Nodejitsu Inc.
+ * (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/mongohq/database/client/databases.js
+++ b/lib/pkgcloud/mongohq/database/client/databases.js
@@ -1,7 +1,7 @@
 /*
  * database.js: Database methods for working with databases from MongoHQ
  *
- * (C) 2012 Nodejitsu Inc.
+ * (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/mongohq/database/client/index.js
+++ b/lib/pkgcloud/mongohq/database/client/index.js
@@ -1,7 +1,7 @@
 /*
  * index.js: Database client for MongoHQ Cloud Databases
  *
- * (C) 2012 Nodejitsu Inc.
+ * (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/mongohq/database/index.js
+++ b/lib/pkgcloud/mongohq/database/index.js
@@ -1,7 +1,7 @@
 /*
  * index.js: Top-level include for the MongoHQ database module
  *
- * (C) 2012 Nodejitsu Inc.
+ * (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/mongohq/index.js
+++ b/lib/pkgcloud/mongohq/index.js
@@ -1,7 +1,7 @@
 /*
  * index.js: Top-level include for the mongohq module.
  *
- * (C) 2012 Nodejitsu Inc.
+ * (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/mongolab/database/client/accounts.js
+++ b/lib/pkgcloud/mongolab/database/client/accounts.js
@@ -1,7 +1,7 @@
 /*
  * accounts.js: Accounts methods for working with databases from MongoLab
  *
- * (C) 2012 Nodejitsu Inc.
+ * (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/mongolab/database/client/databases.js
+++ b/lib/pkgcloud/mongolab/database/client/databases.js
@@ -1,7 +1,7 @@
 /*
  * database.js: Database methods for working with databases from MongoLab
  *
- * (C) 2012 Nodejitsu Inc.
+ * (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/mongolab/database/client/index.js
+++ b/lib/pkgcloud/mongolab/database/client/index.js
@@ -1,7 +1,7 @@
 /*
  * index.js: Database client for MongoLab databases
  *
- * (C) 2012 Nodejitsu Inc.
+ * (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/mongolab/database/index.js
+++ b/lib/pkgcloud/mongolab/database/index.js
@@ -1,7 +1,7 @@
 /*
  * index.js: Top-level include for the MongoLab database module
  *
- * (C) 2012 Nodejitsu Inc.
+ * (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/mongolab/index.js
+++ b/lib/pkgcloud/mongolab/index.js
@@ -1,7 +1,7 @@
 /*
  * index.js: Top-level include for the MongoLab module.
  *
- * (C) 2012 Nodejitsu Inc.
+ * (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/openstack/client.js
+++ b/lib/pkgcloud/openstack/client.js
@@ -1,7 +1,7 @@
 /*
  * client.js: Base client from which all OpenStack clients inherit from
  *
- * (C) 2013 Nodejitsu Inc.
+ * (C) 2013 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/openstack/compute/client/extensions/keys.js
+++ b/lib/pkgcloud/openstack/compute/client/extensions/keys.js
@@ -1,7 +1,7 @@
 /*
  * keys.js Implementation of OpenStack KeyPair API
  *
- * (C) 2013, Nodejitsu Inc.
+ * (C) 2013 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/openstack/compute/client/flavors.js
+++ b/lib/pkgcloud/openstack/compute/client/flavors.js
@@ -1,7 +1,7 @@
 /*
  * flavors.js: Implementation of OpenStack Flavors Client.
  *
- * (C) 2013, Nodejitsu Inc.
+ * (C) 2013 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 var pkgcloud = require('../../../../../lib/pkgcloud'),

--- a/lib/pkgcloud/openstack/compute/client/images.js
+++ b/lib/pkgcloud/openstack/compute/client/images.js
@@ -1,7 +1,7 @@
 /*
  * images.js: Implementation of OpenStack Images Client.
  *
- * (C) 2013, Nodejitsu Inc.
+ * (C) 2013 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 var pkgcloud = require('../../../../../lib/pkgcloud'),

--- a/lib/pkgcloud/openstack/compute/client/index.js
+++ b/lib/pkgcloud/openstack/compute/client/index.js
@@ -1,7 +1,7 @@
 /*
  * index.js: Compute client for OpenStack
  *
- * (C) 2013 Nodejitsu Inc.
+ * (C) 2013 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/openstack/compute/client/servers.js
+++ b/lib/pkgcloud/openstack/compute/client/servers.js
@@ -1,7 +1,7 @@
 /*
  * servers.js: Instance methods for working with servers from OpenStack Cloud
  *
- * (C) 2013 Nodejitsu Inc.
+ * (C) 2013 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 var base     = require('../../../core/compute'),

--- a/lib/pkgcloud/openstack/compute/flavor.js
+++ b/lib/pkgcloud/openstack/compute/flavor.js
@@ -1,7 +1,7 @@
 /*
  * flavor.js: OpenStack Cloud flavor
  *
- * (C) 2013 Nodejitsu Inc.
+ * (C) 2013 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/openstack/compute/image.js
+++ b/lib/pkgcloud/openstack/compute/image.js
@@ -1,7 +1,7 @@
 /*
  * image.js: OpenStack Cloud image
  *
- * (C) 2013 Nodejitsu Inc.
+ * (C) 2013 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/openstack/compute/index.js
+++ b/lib/pkgcloud/openstack/compute/index.js
@@ -1,7 +1,7 @@
 /*
  * index.js: Top-level include for the OpenStack compute module
  *
- * (C) 2013 Nodejitsu Inc.
+ * (C) 2013 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/openstack/compute/server.js
+++ b/lib/pkgcloud/openstack/compute/server.js
@@ -1,7 +1,7 @@
 /*
  * server.js: OpenStack Cloud server
  *
- * (C) 2013 Nodejitsu Inc.
+ * (C) 2013 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/openstack/context/index.js
+++ b/lib/pkgcloud/openstack/context/index.js
@@ -1,7 +1,7 @@
 /*
  * index.js: Top-level include for the OpenStack identity module
  *
- * (C) 2013 Nodejitsu Inc.
+ * (C) 2013 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/openstack/identity/index.js
+++ b/lib/pkgcloud/openstack/identity/index.js
@@ -1,7 +1,7 @@
 /*
  * index.js: Top-level include for the OpenStack identity module
  *
- * (C) 2013 Nodejitsu Inc.
+ * (C) 2013 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/openstack/index.js
+++ b/lib/pkgcloud/openstack/index.js
@@ -1,7 +1,7 @@
 /*
  * index.js: Top-level include for the OpenStack module.
  *
- * (C) 2013 Nodejitsu Inc.
+ * (C) 2013 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/rackspace/client.js
+++ b/lib/pkgcloud/rackspace/client.js
@@ -1,7 +1,7 @@
 /*
  * client.js: Base client from which all Rackspace clients inherit from
  *
- * (C) 2011 Nodejitsu Inc.
+ * (C) 2011 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/rackspace/compute/client/index.js
+++ b/lib/pkgcloud/rackspace/compute/client/index.js
@@ -1,7 +1,7 @@
 /*
  * client.js: Compute client for Rackspace Cloudservers
  *
- * (C) 2011 Nodejitsu Inc.
+ * (C) 2011 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/rackspace/compute/index.js
+++ b/lib/pkgcloud/rackspace/compute/index.js
@@ -1,7 +1,7 @@
   /*
  * index.js: Top-level include for the Rackspace compute module
  *
- * (C) 2011 Nodejitsu Inc.
+ * (C) 2011 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/rackspace/database/client/index.js
+++ b/lib/pkgcloud/rackspace/database/client/index.js
@@ -1,7 +1,7 @@
 /*
  * client.js: Database client for Rackspace Cloud Databases
  *
- * (C) 2011 Nodejitsu Inc.
+ * (C) 2011 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/rackspace/database/index.js
+++ b/lib/pkgcloud/rackspace/database/index.js
@@ -1,7 +1,7 @@
 /*
  * index.js: Top-level include for the Rackspace database module
  *
- * (C) 2011 Nodejitsu Inc.
+ * (C) 2011 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/rackspace/index.js
+++ b/lib/pkgcloud/rackspace/index.js
@@ -1,7 +1,7 @@
 /*
  * index.js: Top-level include for the Rackspace module.
  *
- * (C) 2011 Nodejitsu Inc.
+ * (C) 2011 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/rackspace/storage/client/cdn-containers.js
+++ b/lib/pkgcloud/rackspace/storage/client/cdn-containers.js
@@ -1,7 +1,7 @@
 /*
  * cdn-containers.js: Instance methods for working with containers from Rackspace Cloudfiles
  *
- * (C) 2011 Nodejitsu Inc.
+ * (C) 2011 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/rackspace/storage/client/index.js
+++ b/lib/pkgcloud/rackspace/storage/client/index.js
@@ -1,7 +1,7 @@
 /*
  * client.js: Compute client for Rackspace Cloudservers
  *
- * (C) 2011 Nodejitsu Inc.
+ * (C) 2011 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/redistogo/database/client/index.js
+++ b/lib/pkgcloud/redistogo/database/client/index.js
@@ -1,7 +1,7 @@
 /*
  * client.js: Database client for RedisToGo Cloud Databases
  *
- * (C) 2011 Nodejitsu Inc.
+ * (C) 2011 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/redistogo/database/index.js
+++ b/lib/pkgcloud/redistogo/database/index.js
@@ -1,7 +1,7 @@
 /*
  * index.js: Top-level include for the RedisToGo database module
  *
- * (C) 2011 Nodejitsu Inc.
+ * (C) 2011 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/redistogo/index.js
+++ b/lib/pkgcloud/redistogo/index.js
@@ -1,7 +1,7 @@
 /*
  * index.js: Top-level include for the RedisToGo module.
  *
- * (C) 2011 Nodejitsu Inc.
+ * (C) 2011 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/telefonica/compute/client.js
+++ b/lib/pkgcloud/telefonica/compute/client.js
@@ -1,7 +1,7 @@
 /*
  * index.js: Compute client for Telefonica InstantServers CloudAPI
  *
- * (C) 2012 Nodejitsu Inc.
+ * (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/telefonica/compute/index.js
+++ b/lib/pkgcloud/telefonica/compute/index.js
@@ -1,7 +1,7 @@
 /*
  * index.js: Top-level include for the Telefonica compute module
  *
- * (C) 2012 Nodejitsu Inc.
+ * (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/lib/pkgcloud/telefonica/index.js
+++ b/lib/pkgcloud/telefonica/index.js
@@ -1,7 +1,7 @@
 /*
  * index.js: Top-level include for the Telefonica module.
  *
- * (C) 2012 Nodejitsu Inc.
+ * (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/package.json
+++ b/package.json
@@ -2,15 +2,15 @@
   "name": "pkgcloud",
   "description": "An infrastructure-as-a-service agnostic cloud library for node.js",
   "version": "1.1.0",
-  "author": "Nodejitsu Inc <info@nodejitsu.com>",
+  "author": "Charlie Robbins <charlie.robbins@gmail.com>",
   "contributors": [
-    {
-      "name": "Charlie Robbins",
-      "email": "charlie@nodejitsu.com"
-    },
     {
       "name": "Nuno Job",
       "email": "nuno@nodejitsu.com"
+    },
+    {
+      "name": "Maciej Malecki",
+      "email": "me@mmalecki.com"
     },
     {
       "name": "Daniel Aristizabal",
@@ -19,6 +19,10 @@
     {
       "name": "Ken Perkins",
       "email": "ken.perkins@rackspace.com"
+    },
+    {
+      "name": "Ross Kukulinski",
+      "email": "ross@getyodlr.com"
     }
   ],
   "repository": {

--- a/test/common/base/client-test.js
+++ b/test/common/base/client-test.js
@@ -1,7 +1,7 @@
 /*
 * client-test.js: Tests for pkgcloud base client
 *
-* (C) 2012 Nodejitsu Inc.
+* (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
 *
 */
 

--- a/test/common/compute/base-test.js
+++ b/test/common/compute/base-test.js
@@ -1,7 +1,7 @@
 /*
  * base-test.js: Test that should be common to all providers.
  *
- * (C) 2013 Nodejitsu Inc.
+ * (C) 2013 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/test/common/compute/meta-test.js
+++ b/test/common/compute/meta-test.js
@@ -1,7 +1,7 @@
 /*
 * meta-test.js: Openstack updateImageMeta() function test .
 *
-* (C) 2012 Nodejitsu Inc.
+* (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
 *
 */
 
@@ -85,9 +85,9 @@ providers.filter(function (provider) {
           server: hockInstance
         });
       }
-	
+
       var testMetadata = {os_type: 'windows'};
-	
+
       client.updateImageMeta(context.images[0].id, testMetadata, function (err, reply) {
         should.not.exist(err);
         should.exist(reply);

--- a/test/common/compute/server-test.js
+++ b/test/common/compute/server-test.js
@@ -1,7 +1,7 @@
 /*
 * server-test.js: Test that should be common to all providers.
 *
-* (C) 2012 Nodejitsu Inc.
+* (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
 *
 */
 

--- a/test/common/compute/signature-test.js
+++ b/test/common/compute/signature-test.js
@@ -1,7 +1,7 @@
 /*
  * signature-test.js: Test that shared methods meet some expectations for arguments.
  *
- * (C) 2013 Nodejitsu Inc.
+ * (C) 2013 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/test/common/storage/base-test.js
+++ b/test/common/storage/base-test.js
@@ -1,7 +1,7 @@
 /*
 * base-test.js: Test that should be common to all providers.
 *
-* (C) 2012 Nodejitsu Inc.
+* (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
 *
 */
 

--- a/test/common/storage/upload-test.js
+++ b/test/common/storage/upload-test.js
@@ -1,7 +1,7 @@
 /*
  * base-test.js: Test that should be common to all providers.
  *
- * (C) 2012 Nodejitsu Inc.
+ * (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/test/hp/macros.js
+++ b/test/hp/macros.js
@@ -1,7 +1,7 @@
 /*
  * macros.js: Tests macros for Rackspace
  *
- * (C) 2011 Nodejitsu Inc.
+ * (C) 2011 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/test/iriscouch/databases/databases-redis-test.js
+++ b/test/iriscouch/databases/databases-redis-test.js
@@ -1,7 +1,7 @@
 /*
 * databases-redis-test.js: Tests for IrisCouch Redis database service
 *
-* (C) 2012 Nodejitsu Inc.
+* (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
 * MIT LICENSE
 *
 */
@@ -33,7 +33,7 @@ describe('pkgcloud/iriscouch/databases-redis', function () {
   it('the create() method with correct options should respond correctly', function(done) {
     var subdomain = (mock ? 'nodejitsudb43639' : 'nodejitsudb' + Math.floor(Math.random() * 100000));
     context.tempPassword = (mock ? 'sTTi:lh9vCF[' : randomPassword(12).replace('\\', ''));
-    
+
     if (mock) {
       hockInstance
         .post('/hosting_public', helpers.loadFixture('iriscouch/database-redis.json'))
@@ -42,7 +42,7 @@ describe('pkgcloud/iriscouch/databases-redis', function () {
           rev: '1-63cf360ebc115cdc8a709a910fdef6d7'
         });
     }
-    
+
     client.create({
       subdomain: subdomain,
       first_name: 'Marak',

--- a/test/iriscouch/databases/databases-test.js
+++ b/test/iriscouch/databases/databases-test.js
@@ -1,7 +1,7 @@
 /*
  * databases-test.js: Tests for IrisCouch database service
  *
- * (C) 2012 Nodejitsu Inc.
+ * (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  * MIT LICENSE
  *
  */

--- a/test/mongohq/databases/databases-test.js
+++ b/test/mongohq/databases/databases-test.js
@@ -1,7 +1,7 @@
 /*
 * databases-test.js: Tests for MongoHQ databases service
 *
-* (C) 2012 Nodejitsu Inc.
+* (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
 * MIT LICENSE
 *
 */

--- a/test/mongolab/databases/databases-test.js
+++ b/test/mongolab/databases/databases-test.js
@@ -1,7 +1,7 @@
 /*
 * databases-test.js: Tests for MongoLab databases service
 *
-* (C) 2012 Nodejitsu Inc.
+* (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
 * MIT LICENSE
 *
 */
@@ -117,7 +117,7 @@ describe('pkgcloud/mongolab/databases', function () {
     });
 
     it('with numbers should respond with success', function(done) {
-      
+
       if (mock) {
         hockInstance
           .post('/api/1/partners/nodejitsu/accounts', {
@@ -129,7 +129,7 @@ describe('pkgcloud/mongolab/databases', function () {
           })
           .reply(200, helpers.loadFixture('mongolab/customUser.json'));
       }
-      
+
       client.createAccount({
         name: 'custompassword',
         email: 'custom@password.com',
@@ -149,7 +149,7 @@ describe('pkgcloud/mongolab/databases', function () {
   });
 
   it('the getAccounts() method should respond with all accounts', function(done) {
-    
+
     if (mock) {
       hockInstance
         .get('/api/1/partners/nodejitsu/accounts')
@@ -170,7 +170,7 @@ describe('pkgcloud/mongolab/databases', function () {
       done();
     });
   });
-  
+
   it('the getAccount() method should return the matching account', function(done) {
 
     if (mock) {
@@ -194,7 +194,7 @@ describe('pkgcloud/mongolab/databases', function () {
       hockInstance && hockInstance.done();
       done();
     });
-    
+
   });
 
   it('the create() method with correct options should respond correctly', function (done) {
@@ -266,7 +266,7 @@ describe('pkgcloud/mongolab/databases', function () {
         databases[0].should.be.a.Object;
         databases[0].name.should.equal(context.account.username + '_testDatabase');
         context.databaseName = databases[0].name;
-        
+
         hockInstance && hockInstance.done();
         done();
       });

--- a/test/rackspace/compute/authentication-test.js
+++ b/test/rackspace/compute/authentication-test.js
@@ -1,7 +1,7 @@
 /*
 * authentication-test.js: Tests for pkgcloud Rackspace compute authentication
 *
-* (C) 2010 Nodejitsu Inc.
+* (C) 2010 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
 *
 */
 

--- a/test/rackspace/compute/image-test.js
+++ b/test/rackspace/compute/image-test.js
@@ -1,7 +1,7 @@
 /*
 * image-test.js: Tests for pkgcloud Rackspace compute image requests
 *
-* (C) 2010-2012 Nodejitsu Inc.
+* (C) 2010-2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
 * MIT LICENSE
 *
 */
@@ -94,7 +94,7 @@ describe('pkgcloud/rackspace/compute/images', function () {
         done();
       });
     });
-    
+
     after(function(done) {
 
       if (mock) {

--- a/test/rackspace/compute/personality-test.js
+++ b/test/rackspace/compute/personality-test.js
@@ -2,7 +2,7 @@
 * personality-test.js: tests cloudserver's ability to add files
 *                      to a server's filesystem during creationg
 *
-* (C) 2010 Nodejitsu Inc.
+* (C) 2010 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
 * MIT LICENSE
 *
 */

--- a/test/rackspace/databases/authentication-test.js
+++ b/test/rackspace/databases/authentication-test.js
@@ -2,7 +2,7 @@
 /*
  * authentication-test.js: Tests for pkgcloud Rackspace compute authentication
  *
- * (C) 2010 Nodejitsu Inc.
+ * (C) 2010 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/test/rackspace/databases/user-limit-test.js
+++ b/test/rackspace/databases/user-limit-test.js
@@ -1,7 +1,7 @@
 /*
  * users-limit-test.js: Tests for Cloud Database users within an instace
  *
- * (C) 2010 Nodejitsu Inc.
+ * (C) 2010 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  * MIT LICENSE
  *
  */

--- a/test/rackspace/macros.js
+++ b/test/rackspace/macros.js
@@ -1,7 +1,7 @@
 /*
  * macros.js: Tests macros for Rackspace
  *
- * (C) 2011 Nodejitsu Inc.
+ * (C) 2011 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  *
  */
 

--- a/test/rackspace/storage/authentication-test.js
+++ b/test/rackspace/storage/authentication-test.js
@@ -1,7 +1,7 @@
 /*
 * authentication-test.js: Tests for pkgcloud Rackspace storage authentication
 *
-* (C) 2010 Nodejitsu Inc.
+* (C) 2010 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
 *
 */
 

--- a/test/rackspace/storage/container-test.js
+++ b/test/rackspace/storage/container-test.js
@@ -1,7 +1,7 @@
 /*
 * container-test.js: Tests for Rackspace Cloudfiles containers
 *
-* (C) 2010 Nodejitsu Inc.
+* (C) 2010 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
 * MIT LICENSE
 *
 */

--- a/test/rackspace/storage/storage-object-large-test.js
+++ b/test/rackspace/storage/storage-object-large-test.js
@@ -1,7 +1,7 @@
 /*
  * container-test.js: Tests for Rackspace Cloudfiles containers
  *
- * (C) 2010 Nodejitsu Inc.
+ * (C) 2010 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  * MIT LICENSE
  *
  */

--- a/test/rackspace/storage/storage-object-metadata-test.js
+++ b/test/rackspace/storage/storage-object-metadata-test.js
@@ -1,7 +1,7 @@
 /*
  * container-test.js: Tests for Rackspace Cloudfiles containers
  *
- * (C) 2010 Nodejitsu Inc.
+ * (C) 2010 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  * MIT LICENSE
  *
  */

--- a/test/rackspace/storage/storage-object-noauth-test.js
+++ b/test/rackspace/storage/storage-object-noauth-test.js
@@ -1,7 +1,7 @@
 ///*
 // * storage-object-test.js: Tests for uploading files to Rackspace Cloudfiles when not authenticated.
 // *
-// * (C) 2010 Nodejitsu Inc.
+// * (C) 2010 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
 // * MIT LICENSE
 // *
 // */

--- a/test/rackspace/storage/storage-object-test.js
+++ b/test/rackspace/storage/storage-object-test.js
@@ -1,7 +1,7 @@
 /*
  * storage-object-test.js: Tests for Rackspace Cloudfiles containers
  *
- * (C) 2010 Nodejitsu Inc.
+ * (C) 2010 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
  * MIT LICENSE
  *
  */
@@ -249,11 +249,11 @@ describe('pkgcloud/rackspace/storage/storage-object', function () {
     });
 
     it('extract should ask server to extract the uploaded tar file', function(done) {
-      
+
       var data = 'H4sIABub81EAA+3TzUrEMBAH8CiIeNKTXvMC1nxuVzx58CiC9uBNam1kQZt1N4X1XXwDX9IJXVi6UDxo6sH/D4akadJOmY7z/owlJkhubTdOulEo040dJpXMTS6tjuuSriTjNnViUbsM5YJztvCPs+atHdxH25wbI6FxOap/9hDqZcjCKqR5RyzwxJjB+iurN/WXiuqvpdGMizTp9P3z+rO94322y9h1WfGbO37P1+IaO6BQFO8U8fqzd/Jo6JGXRXG7nsYTHxSHW1t2NusnlX/Nyvn8pc6KehWumso/zZpnutkGdzq9kNrQv3E+Nb/yudAX+z9t93/f/0LIrf5XNEP/j0H+dQIAAAAAAAAAAAAAAAAAAADwY194ELb5ACgAAA==';
       var tmp = './foo.tar.gz';
       fs.writeFileSync(tmp, new Buffer(data, 'base64'));
-      
+
       if (mock) {
         authHockInstance
           .post('/v2.0/tokens', {
@@ -270,27 +270,27 @@ describe('pkgcloud/rackspace/storage/storage-object', function () {
           .put('/v1/MossoCloudFS_00aa00aa-aa00-aa00-aa00-aa00aa00aa00?extract-archive=tar.gz', new Buffer(data, 'base64').toString())
           .replyWithFile(200, __dirname + '/../../fixtures/rackspace/extract.json');
       }
-      
-      
-      
+
+
+
       client.extract({
         local: tmp
       }, function(e, ok, resp) {
         should.not.exist(e);
         should.exist(resp);
         hockInstance && hockInstance.done();
-        
+
         fs.unlinkSync(tmp);
         done();
       });
-      
+
     });
 
     after(function (done) {
       if (!mock) {
         return done();
       }
-      
+
 
       async.parallel([
         function (next) {

--- a/test/redistogo/databases/databases-test.js
+++ b/test/redistogo/databases/databases-test.js
@@ -1,7 +1,7 @@
 /*
 * databases-test.js: Tests for Redistogo databases service
 *
-* (C) 2012 Nodejitsu Inc.
+* (C) 2012 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
 * MIT LICENSE
 *
 */


### PR DESCRIPTION
Been meaning to do this for a while. Thought I would get it done before I probably say @kenperkins at SeattleJS tonight :sunglasses: ... also we should consider adding:

- `CONTRIBUTORS.md`
- Developer Certifiate of Origin

Since there are a lot of other floating `(C) XYZ` notices the latter is probably somewhat important. 