### PR TITLE
[dist] upgrade aws-sdk dependency to 2.1.17

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   ],
   "dependencies": {
     "async": "0.9.x",
-    "aws-sdk": "~2.0.17",
+    "aws-sdk": "^2.1.17",
     "errs": "0.3.x",
     "eventemitter2": "0.4.x",
     "filed": "0.1.x",


### PR DESCRIPTION
fix "memory usage bug when downloading objects from Amazon S3" motivated by email from Amazon:

> Dear Amazon Web Services Customer,
> 
> Our logs indicate that your account has used or is using a version of the AWS SDK for JavaScript that  is affected by a memory usage bug when downloading objects from Amazon S3. The affected versions are 2.1.13, 2.1.14, and 2.1.15.
> 
> The latest 2.1.16 version of the SDK includes the related fix, and it is critical that you upgrade to the latest version to avoid being affected by it.