### PR TITLE
Flip the keyId and key in Amazon examples

### DIFF
--- a/docs/providers/amazon.md
+++ b/docs/providers/amazon.md
@@ -12,8 +12,8 @@ For all of the Amazon services, you create a client with the same options:
 ```Javascript
 var client = require('pkgcloud').compute.createClient({
    provider: 'amazon',
-   key: 'your-secret-key-id', // secret key
    keyId: 'your-access-key-id', // access key id
+   key: 'your-secret-key-id', // secret key
    region: 'us-west-2' // region
 });
 ```
@@ -21,8 +21,8 @@ var client = require('pkgcloud').compute.createClient({
 ```Javascript
 var client = require('pkgcloud').storage.createClient({
    provider: 'amazon',
-   key: 'your-secret-key-id', // secret key
    keyId: 'your-access-key-id', // access key id
+   key: 'your-secret-key-id', // secret key
    region: 'us-west-2' // region
 });
 ```


### PR DESCRIPTION
Typical AWS examples and even the AWS interfaces that output access keys output the access key id first, then the secret key.

This makes the examples confusing and likely someone will insert the wrong value for the wrong key.