### PR TITLE
New feature: add 'name' to AWS instance.

### DIFF
--- a/lib/pkgcloud/amazon/compute/client/servers.js
+++ b/lib/pkgcloud/amazon/compute/client/servers.js
@@ -192,7 +192,18 @@ exports.createServer = function createServer(options, callback) {
       server = new compute.Server(self, instance);
     });
 
-    callback(null, server);
+    if (server && options.name) {
+      // Add tags to the instance
+      var params = {Resources: [server.id], Tags: [{Key: 'Name', Value: options.name}]};
+      self.ec2.createTags(params, function(err) {
+        if (err) {
+          return callback(err);
+        }
+        callback(null, server);
+      });
+    } else {
+      callback(null, server);
+    }
   });
 };
 


### PR DESCRIPTION
If a 'name' field is added, set the instance tag so it shows up in the AWS console. Otherwise the "Name" column in the AWS console is blank. This is not the instance name, which is still correct, but the tag "Name" which is what the AWS console uses.

See http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-examples.html