### PR TITLE
amazon createServer: use pluralized keys for SecurityGroups/SecurityGroupIds

### DIFF
--- a/lib/pkgcloud/amazon/compute/client/servers.js
+++ b/lib/pkgcloud/amazon/compute/client/servers.js
@@ -154,12 +154,12 @@ exports.createServer = function createServer(options, callback) {
 
   securityGroup = this.securityGroup || options['SecurityGroup'];
   if (securityGroup) {
-    createOptions['SecurityGroup'] = securityGroup;
+    createOptions['SecurityGroups'] = [securityGroup];
   }
 
   securityGroupId = this.securityGroupId || options['SecurityGroupId'];
   if (securityGroupId) {
-    createOptions['SecurityGroupId'] = securityGroupId;
+    createOptions['SecurityGroupIds'] = [securityGroupId];
   }
 
   createOptions.ImageId = options.image instanceof base.Image


### PR DESCRIPTION
Fixes #432