### PR TITLE
Add availability zone options in openstack provider

### DIFF
--- a/lib/pkgcloud/openstack/blockstorage/client/volumes.js
+++ b/lib/pkgcloud/openstack/blockstorage/client/volumes.js
@@ -78,6 +78,7 @@ exports.getVolume = function (volume, callback) {
  * @param {number}      options.size   the size of the new volume in GB
  * @param {String}      [options.snapshotId]   the snapshotId to use in creating the new volume
  * @param {object|String}      [options.volumeType]    the volumeType for the new volume
+ * @param {object|String}      [options.availabilityZone] the availability zone for the new volume
  * @param {function}    callback
  * @returns {*}
  */
@@ -105,6 +106,10 @@ exports.createVolume = function (options, callback) {
 
   if (options.snapshotId) {
     createOptions.body.volume['snapshot_id'] = options.snapshotId;
+  }
+
+  if (options.availabilityZone) {
+    createOptions.body.volume['availability_zone'] = options.availabilityZone;
   }
 
   self._request(createOptions, function (err, body) {

--- a/lib/pkgcloud/openstack/blockstorage/volume.js
+++ b/lib/pkgcloud/openstack/blockstorage/volume.js
@@ -27,11 +27,12 @@ Volume.prototype._setProperties = function (details) {
   this.volumeType = details.volumeType || details['volume_type'];
   this.attachments = details.attachments;
   this.snapshotId = details.snapshotId || details['snapshot_id'];
+  this.availabilityZone = details['availability_zone'];
 };
 
 Volume.prototype.toJSON = function () {
   return _.pick(this, ['id', 'status', 'name', 'description', 'createdAt',
-    'size', 'volumeType', 'attachments', 'snapshotId']);
+    'size', 'volumeType', 'attachments', 'snapshotId', 'availabilityZone']);
 };
 
 

--- a/lib/pkgcloud/openstack/compute/client/servers.js
+++ b/lib/pkgcloud/openstack/compute/client/servers.js
@@ -124,6 +124,7 @@ exports.getServers = function getServers(options, callback) {
  * @param {Object}          [details.keyname]     optional keyname configuration
  * @param {Object}          [details.personality] optional personality configuration
  * @param {Object}          [details.metadata]    optional metadata configuration
+ * @param {Object|String}   [details.availabilityZone] optional the availability zone to use
  * @param callback
  * @returns {request|*}
  */
@@ -176,6 +177,10 @@ exports.createServer = function createServer(details, callback) {
   if (details.cloudConfig) {
     createOptions.body.server.user_data = details.cloudConfig;
     createOptions.body.server.config_drive = true;
+  }
+
+  if (details.availabilityZone) {
+    createOptions.body.server.availability_zone = details.availabilityZone;
   }
 
   return this._request(createOptions, function (err, body) {

--- a/lib/pkgcloud/openstack/compute/server.js
+++ b/lib/pkgcloud/openstack/compute/server.js
@@ -72,6 +72,7 @@ Server.prototype._setProperties = function (details) {
   this.created   = details.created   || this.created;
   this.updated   = details.updated   || this.updated;
   this.original  = this.openstack = details;
+  this['OS-EXT-AZ:availability_zone'] = details['OS-EXT-AZ:availability_zone'];
 
   if (Object.keys(this.addresses).length && !this.addresses.public
     && !this.addresses.private) {
@@ -139,5 +140,5 @@ Server.prototype.toJSON = function() {
     'links', 'key_name', 'imageId', 'flavorId', 'user_id', 'tenant_id', 'progress',
     'OS-EXT-STS:task_state', 'OS-EXT-STS:vm_state', 'OS-EXT-STS:power_state',
     'OS-DCF:diskConfig', 'accessIPv4', 'accessIPv6', 'config_drive', 'metadata',
-    'created', 'updated']);
+    'created', 'updated', 'OS-EXT-AZ:availability_zone']);
 };


### PR DESCRIPTION
Allow specification of availability zone when creating a new server or volume.

In the environment I use, when an availability zone is not specified in the api call, the resource will always be created in the same, default, availability zone. This makes it difficult to construct a HA environment that spans multiple az's.

Unfortunately availabilityZone (or availability_zone in wire format) is a long variable name so I may be hitting some column limits! Please advise if this can be improved.