### PR TITLE
auth: only set x-auth-project-id header if truthy

### DIFF
--- a/lib/pkgcloud/common/auth.js
+++ b/lib/pkgcloud/common/auth.js
@@ -24,7 +24,9 @@ auth.basic = function basicAuth(req) {
 // Add Account number for requests to rackspace API
 auth.accountId = function (req) {
   req.headers = req.headers || {};
-  req.headers['x-auth-project-id'] = this.config.accountNumber;
+  if (this.config.accountNumber) {
+    req.headers['x-auth-project-id'] = this.config.accountNumber;
+  }
 };
 
 function signatureGenerator(sign) {


### PR DESCRIPTION
This makes all tests pass on iojs.
https://github.com/iojs/io.js/commit/979d0ca874df0383311ca06f154f6965074
196ee introduced throwing an error when the header value is undefined.