### PR TITLE
[database]: Add enableRootUser and listRootStatus

### DIFF
--- a/docs/providers/rackspace/databases.md
+++ b/docs/providers/rackspace/databases.md
@@ -91,3 +91,31 @@ A user object is defined as follows:
 
 **note**: If creating multiple users, the instance provided must be the same for
 both.
+
+#### client.listRootStatus(instance, callback)
+
+Checks if the root user is enabled for the passed instance.
+
+```js
+client.listRootStatus(instance, function (err, result) {
+  // handle err
+  console.log(result); // => { rootEnabled: true }
+});
+```
+
+#### client.enableRootUser(instance, callback)
+
+Enables the root user for the passed instance.
+
+```js
+client.enableRootUser(instance, function (err, result) {
+  // handle err
+  console.log(result);
+  // => {
+  // =>   user: {
+  // =>     name: 'root',
+  // =>     password: '<the generated password>'
+  // =>   }
+  // => }
+});
+```

--- a/lib/pkgcloud/openstack/database/client/instances.js
+++ b/lib/pkgcloud/openstack/database/client/instances.js
@@ -320,3 +320,70 @@ exports.setVolumeSize = function setVolumeSize(instance, newSize, callback) {
     }), callback);
   });
 };
+
+// Enable the root user for the given database instance.
+// ### @instance {string | Object} The ID of the instance or a instance or Instance class (required)
+// ### @callback {Function} Function to continue, the call is cb(error, res)
+exports.enableRootUser = function enableRootUser(instance, callback) {
+  // Check for instance
+  if (typeof instance === 'function' || typeof instance === 'undefined') {
+    return errs.handle(errs.create({
+      message: 'An instance is required.'
+    }), Array.prototype.slice.call(arguments).pop());
+  }
+
+  var instanceId = instance instanceof Instance ? instance.id : instance;
+
+  var options = {
+    method: 'POST',
+    path: 'instances/' + instanceId + '/root'
+  };
+
+  this._request(options, function (err, body, response) {
+    if (err) {
+      return callback(err);
+    }
+
+    if (response.statusCode === 200) {
+      return callback(null, body);
+    }
+
+    return errs.handle(errs.create({
+      message: 'Bad response from enabling root user'
+    }), callback);
+  });
+};
+
+// List the root status for the database instance.
+// `res` will be an object like `{ rootEnabled: true }`
+// ### @instance {string | Object} The ID of the instance or a instance or Instance class (required)
+// ### @callback {Function} Function to continue, the call is cb(error, res)
+exports.listRootStatus = function listRootStatus(instance, callback) {
+  // Check for instance
+  if (typeof instance === 'function' || typeof instance === 'undefined') {
+    return errs.handle(errs.create({
+      message: 'An instance is required.'
+    }), Array.prototype.slice.call(arguments).pop());
+  }
+
+  var instanceId = instance instanceof Instance ? instance.id : instance;
+
+  var options = {
+    method: 'GET',
+    path: 'instances/' + instanceId + '/root'
+  };
+
+  this._request(options, function (err, body, response) {
+    if (err) {
+      return callback(err);
+    }
+
+    if (response.statusCode === 200) {
+      return callback(null, body);
+    }
+
+    return errs.handle(errs.create({
+      message: 'Bad response from listing root-enabled status'
+    }), callback);
+  });
+};

--- a/test/common/databases/instances-test.js
+++ b/test/common/databases/instances-test.js
@@ -19,7 +19,7 @@ var should = require('should'),
 var assertLinks, setupCreateInstanceMock, setupGetInstancesMock,
     setupGetDatabaseInstancesWithLimitMock, setupDestroyInstanceMock,
     setGetInstanceMock, setGetFlavorsMock, setupSetFlavorMock, setupResizeMock,
-    setupGetOneFlavorMock, setupRestartInstanceMock;
+    setupGetOneFlavorMock, setupRestartInstanceMock, setupEnableRootMock;
 
 providers.filter(function (provider) {
   return !!helpers.pkgcloud.providers[provider].database && provider !== 'azure';
@@ -428,6 +428,38 @@ providers.filter(function (provider) {
         });
       });
 
+      if (provider === 'rackspace' || provider === 'openstack') {
+        describe('the enableRootUser() method', function() {
+          it('with no instance should return error', function (done) {
+            if (mock) {
+              setupEnableRootMock(hockInstance, provider);
+            }
+            client.enableRootUser(testContext.Instance.id, function (err, body) {
+              if (err) {
+                return done(err);
+              }
+
+              should.exist(body);
+              body.should.have.property('user');
+              done();
+            });
+          });
+
+          it('with valid instance should work', function (done) {
+            client.listRootStatus(testContext.Instance.id, function (err, body) {
+              if (err) {
+                return done(err);
+              }
+
+              should.exist(body);
+              body.should.have.property('rootEnabled');
+              hockInstance && hockInstance.done();
+              done();
+            });
+          });
+        });
+      }
+
       describe('the restartInstance() method', function () {
         it('with no instance should return error', function (done) {
           client.restartInstance(function (err) {
@@ -748,5 +780,35 @@ setupRestartInstanceMock = function (hockInstance, provider) {
       .reply(200, helpers.loadFixture('hp/databaseInstances.json'))
       .post('/v1.0/5ACED3DC3AA740ABAA41711243CC6949/instances/51a28a3e-2b7b-4b5a-a1ba-99b871af2c8f/action', { restart :{}})
       .reply(202);
+  }
+};
+
+setupEnableRootMock = function (hockInstance, provider) {
+  if (provider === 'rackspace') {
+    hockInstance
+      .post('/v1.0/123456/instances/51a28a3e-2b7b-4b5a-a1ba-99b871af2c8f/root')
+      .reply(200, {
+        user: {
+          name: 'root',
+          password: '12345'
+        }
+      })
+      .get('/v1.0/123456/instances/51a28a3e-2b7b-4b5a-a1ba-99b871af2c8f/root')
+      .reply(200, {
+        rootEnabled: true
+      });
+  } else if (provider === 'openstack') {
+    hockInstance
+      .post('/v1.0/72e90ecb69c44d0296072ea39e537041/instances/51a28a3e-2b7b-4b5a-a1ba-99b871af2c8f/root')
+      .reply(200, {
+        user: {
+          name: 'root',
+          password: '12345'
+        }
+      })
+      .get('/v1.0/72e90ecb69c44d0296072ea39e537041/instances/51a28a3e-2b7b-4b5a-a1ba-99b871af2c8f/root')
+      .reply(200, {
+        rootEnabled: true
+      });
   }
 };


### PR DESCRIPTION
Adds enableRootUser and listRootStatus for rackspace cloud databases.

I understand if this PR exposes more functionality that wanted being as it allows enabling the root user for rackspace databases. Although, it is something that I have actually needed before. If the tests are not up to snuff, I can add more.