### PR TITLE
[database]: use Array.isArray instead of typeof

### DIFF
--- a/lib/pkgcloud/openstack/database/client/instances.js
+++ b/lib/pkgcloud/openstack/database/client/instances.js
@@ -45,7 +45,7 @@ exports.createInstance = function createInstance(options, callback) {
 
   // If the 'databases' are specified we create a template for each database name.
   if (options && options['databases'] &&
-      typeof options['databases'] === 'array' &&
+      Array.isArray(options['databases']) &&
       options['databases'].length > 0) {
     options['databases'].forEach(function (item, idx) {
       if (typeof item === 'string') {

--- a/test/common/databases/instances-test.js
+++ b/test/common/databases/instances-test.js
@@ -68,7 +68,8 @@ providers.filter(function (provider) {
 
             client.createInstance({
               name: 'test-instance',
-              flavor: flavor
+              flavor: flavor,
+              databases: ['db1']
             }, function(e, i) {
               err = e;
               instance = i;
@@ -487,7 +488,11 @@ setupCreateInstanceMock = function (hockInstance,  provider) {
         instance: {
           name: 'test-instance',
           flavorRef: 'https://ord.databases.api.rackspacecloud.com/v1.0/123456/flavors/1',
-          databases: [],
+          databases: [{
+            name: 'db1',
+            character_set: 'utf8',
+            collate: 'utf8_general_ci'
+          }],
           volume: {
             size:1
           }
@@ -503,7 +508,11 @@ setupCreateInstanceMock = function (hockInstance,  provider) {
           instance: {
             name: 'test-instance',
             flavorRef: 'https://ord.databases.api.rackspacecloud.com/v1.0/123456/flavors/1',
-            databases: [],
+            databases: [{
+              name: 'db1',
+              character_set: 'utf8',
+              collate: 'utf8_general_ci'
+            }],
             volume: {
               size:1
             }
@@ -519,7 +528,11 @@ setupCreateInstanceMock = function (hockInstance,  provider) {
           instance: {
             name: 'test-instance',
             flavorRef: 'https://ord.databases.api.rackspacecloud.com/v1.0/123456/flavors/1',
-            databases: [],
+            databases: [{
+              name: 'db1',
+              character_set: 'utf8',
+              collate: 'utf8_general_ci'
+            }],
             volume: {
               size:1
             }


### PR DESCRIPTION
When calling `typeof` on an array, `object` is returned. So creating a database instance and including the database names in the `databases` property will fail.

Ex.

```
> var a = []
undefined
> typeof a
'object'
> Array.isArray(a)
true
> typeof a === 'array'
false
```