### PR TITLE
Added deleteRule

### DIFF
--- a/lib/pkgcloud/openstack/compute/client/extensions/security-group-rules.js
+++ b/lib/pkgcloud/openstack/compute/client/extensions/security-group-rules.js
@@ -78,3 +78,24 @@ exports.addRules = function(rules, callback) {
     callback(null, created);
   });
 };
+
+/**
+ * client.deleteRule
+ *
+ * @description Remove a rule from a security group
+ *
+ * @param {string}      ruleId   the id of the rule to be deleted
+ * @param {Function}    callback
+ * @returns {request|*}
+ */
+exports.deleteRule = function deleteRule(ruleId, callback) {
+
+  return this._request({
+    method: 'DELETE',
+    path: urlJoin(_extension, ruleId)
+  }, function (err) {
+    return err
+      ? callback(err)
+      : callback(err, { ok: ruleId});
+  });
+};

--- a/lib/pkgcloud/openstack/compute/client/extensions/security-group-rules.js
+++ b/lib/pkgcloud/openstack/compute/client/extensions/security-group-rules.js
@@ -6,7 +6,7 @@
  */
 
 var async = require('async');
-
+var urlJoin = require('url-join');
 var _extension = 'os-security-group-rules';
 
 /**


### PR DESCRIPTION
Issue #453 described that
openstack/compute/client/extensions/security-group-rules.js lacked the
deleteRule method.