### PR TITLE
Add getGroup method to openstack security-group client

### DIFF
--- a/lib/pkgcloud/openstack/compute/client/extensions/security-groups.js
+++ b/lib/pkgcloud/openstack/compute/client/extensions/security-groups.js
@@ -10,6 +10,26 @@ var urlJoin = require('url-join');
 var _extension = 'os-security-groups';
 
 /**
+ * client.getGroup
+ *
+ * @description Get a security group from the current account
+ *
+ * @param {String}    id    The id of the group to get
+ * @param {Function}  callback
+ * @returns {*}
+ */
+exports.getGroup = function getGroup(id, callback) {
+  return this._request({
+    path: urlJoin(_extension, id)
+  }, function (err, body) {
+    return err
+      ? callback(err)
+      : callback(null, body['security_group']);
+  });
+};
+
+
+/**
  * client.listGroups
  *
  * @description List security groups for the current compute client


### PR DESCRIPTION
Currently getGroup is missing from lib/pkgcloud/openstack/compute/client/extensions/security-groups.js