### PR TITLE
OpenStack Keystone/Identity V3 Updates

### DIFF
--- a/lib/pkgcloud/openstack/client.js
+++ b/lib/pkgcloud/openstack/client.js
@@ -2,6 +2,7 @@
  * client.js: Base client from which all OpenStack clients inherit from
  *
  * (C) 2013 Charlie Robbins, Ken Perkins, Ross Kukulinski & the Contributors.
+ * (C) 2015 IBM Corp.
  *
  */
 
@@ -36,6 +37,7 @@ var Client = exports.Client = function (options) {
   this.region     = options.region;
   this.tenantId   = options.tenantId;
   this.version    = options.version || 'v2.0';
+  this.keystoneAuthVersion = options.keystoneAuthVersion || 'v2.0';
 
   if (!/^http[s]?\:\/\//.test(this.authUrl)) {
     this.authUrl = 'http://' + this.authUrl;
@@ -77,11 +79,24 @@ Client.prototype._getIdentityOptions = function() {
     url: this.authUrl,
     version: this.version,
     username: this.config.username,
-    password: this.config.password
+    password: this.config.password,
+    keystoneAuthVersion: this.keystoneAuthVersion
   };
 
   options.strictSSL = typeof this.config.strictSSL === 'boolean'
   ? this.config.strictSSL : true;
+
+  if (this.config.domainId) {
+    options.domainId = this.config.domainId;
+  } else if (this.config.domainName) {
+    options.domainName = this.config.domainName;
+  }
+
+  if (this.config.projectDomainName) {
+    options.projectDomainName = this.config.projectDomainName;
+  } else if (this.config.projectDomainId) {
+    options.projectDomainId = this.config.projectDomainId;
+  }
 
   if (this.config.tenantId) {
     options.tenantId = this.config.tenantId;
@@ -89,11 +104,17 @@ Client.prototype._getIdentityOptions = function() {
   else if (this.config.tenantName) {
     options.tenantName = this.config.tenantName;
   }
+
   if (typeof this.config.useServiceCatalog === 'boolean') {
     options.useServiceCatalog = this.config.useServiceCatalog;
   }
+
   if (this.config.basePath) {
     options.basePath = this.config.basePath;
+  }
+
+  if (this.config.headers) {
+    options.token = this.config.headers.authorization;
   }
 
   return options;
@@ -224,7 +245,6 @@ Client.prototype._request = function (options, callback) {
         apiStream.on('response', function (response) {
           proxyStream.emit('response', response);
         });
-
         apiStream.pipe(proxyStream);
       }
 

--- a/lib/pkgcloud/openstack/context/identity.js
+++ b/lib/pkgcloud/openstack/context/identity.js
@@ -328,10 +328,10 @@ Identity.prototype._buildAuthenticationPayload = function () {
       };
     }
     // Are we filtering down by a tenant?
-    if (self.options.tenantId) {
+    if (self._authenticationPayload && self.options.tenantId) {
       self._authenticationPayload.auth.tenantId = self.options.tenantId;
     }
-    else if (self.options.tenantName) {
+    else if (self._authenticationPayload && self.options.tenantName) {
       self._authenticationPayload.auth.tenantName = self.options.tenantName;
     }
   }

--- a/lib/pkgcloud/openstack/context/identity.js
+++ b/lib/pkgcloud/openstack/context/identity.js
@@ -2,6 +2,7 @@
  * identity.js: Identity for openstack authentication
  *
  * (C) 2013 Rackspace, Ken Perkins
+ * (C) 2015 IBM Corp.
  * MIT LICENSE
  *
  */
@@ -75,7 +76,7 @@ var Identity = exports.Identity = function (options) {
 
   self.options = options || {};
   self.name = 'OpenstackIdentity';
-  self.basePath = options.basePath || '/v2.0/tokens';
+  self.basePath = options.basePath || (options.keystoneAuthVersion === 'v3' ? '/v3/auth/tokens' : '/v2.0/tokens');
   self.useServiceCatalog = (typeof options.useServiceCatalog === 'boolean')
     ? options.useServiceCatalog
     : true;
@@ -114,6 +115,13 @@ Identity.prototype.authorize = function (options, callback) {
       'Accept': 'application/json'
     }
   };
+  if (self.options.headers) {
+    for (var header in self.options.headers) {
+      if (self.options.headers.hasOwnProperty(header)) {
+          authenticationOptions.headers[header] = self.options.headers[header];
+      }
+    }
+  }
 
   if (self.options.version === 1 || self.options.version === '/v1.0') {
     authenticationOptions.uri = urlJoin(options.url || self.options.url, '/auth/v1.0');
@@ -144,7 +152,6 @@ Identity.prototype.authorize = function (options, callback) {
 
   // Don't keep a copy of the credentials in memory
   delete self._authenticationPayload;
-
   request(authenticationOptions, function (err, response, body) {
     // check for a network error, or a handled error
     var err2 = getError(err, response, body);
@@ -162,26 +169,26 @@ Identity.prototype.authorize = function (options, callback) {
 
     // If we've been asked to do v1 auth, check the response headers
     // otherwise, check the body
-    if (self.options.version === 1 || self.options.version === '/v1.0') {
+    try {
+      if (self.options.version === 1 || self.options.version === '/v1.0') {
         self._storageUrl = response.headers['x-storage-url'];
         self.token = {
-            id: response.headers['x-auth-token']
+          id: response.headers['x-auth-token']
         };
         callback();
-    }
-    // If we don't have a tenantId in the response (meaning no service catalog)
-    // go ahead and make a 1-off request to get a tenant and then reauthorize
-    else if (!body.access.token.tenant) {
-      getTenantId(urlJoin(options.url || self.options.url, '/v2.0/tenants'), body.access.token.id);
-    }
-    else {
-      try {
-        self._parseIdentityResponse(body);
+      }
+      // If we don't have a tenantId in the response (meaning no service catalog)
+      // go ahead and make a 1-off request to get a tenant and then reauthorize
+      else if (self.options.keystoneAuthVersion !== 'v3' && !body.access.token.tenant) {
+        getTenantId(urlJoin(options.url || self.options.url, '/v2.0/tenants'), body.access.token.id);
+      }
+      else {
+        self._parseIdentityResponse(body, response.headers);
         callback();
       }
-      catch (e) {
-        callback(e);
-      }
+    }
+    catch (e) {
+      callback(e);
     }
   });
 
@@ -232,27 +239,101 @@ Identity.prototype._buildAuthenticationPayload = function () {
   var self = this;
 
   self.emit('log::trace', 'Building Openstack Identity Auth Payload');
+  if (self.options.keystoneAuthVersion === 'v3') {
+    if (self.options.password) {
+      self._authenticationPayload = {
+        auth: {
+          identity : {
+            methods : ['password'],
+            password : {
+              user: {
+                password: self.options.password
+              }
+            }
+          }
+        }
+      };
 
-  // setup our inputs for authorization
-  if (self.options.password && self.options.username) {
-    self._authenticationPayload = {
-      auth: {
-        passwordCredentials: {
-          username: self.options.username,
-          password: self.options.password
+      //first add user name or id to user field
+      if (self.options.username) {
+        self._authenticationPayload.auth.identity.password.user.name = self.options.username;
+      } else if (self.options.userid) {
+        self._authenticationPayload.auth.identity.password.user.id = self.options.userid;
+      }
+      //check if authenticating against user domain
+      if (self.options.domainId) {
+        self._authenticationPayload.auth.identity.password.user.domain = {id:self.options.domainId};
+      } else if (self.options.domainName) {
+        self._authenticationPayload.auth.identity.password.user.domain = {name:self.options.domainName};
+      }
+      //check if we're getting a scoped token against a project and/or domain
+      if (self.options.tenantId || self.options.tenantName || self.options.projectDomainName || self.options.projectDomainId) {
+        self._authenticationPayload.auth.scope = {};
+        var scopedProject = true;
+        if (self.options.tenantId) {
+          self._authenticationPayload.auth.scope.project = {id:self.options.tenantId};
+        } else  if (self.options.tenantName) {
+          self._authenticationPayload.auth.scope.project = {name:self.options.tenantName};
+        } else {
+          scopedProject = false;
+        }
+        if (!scopedProject) {
+          if (self.options.projectDomainId) {
+            self._authenticationPayload.auth.scope.domain = {id:self.options.projectDomainId};
+          } else if (self.options.projectDomainName) {
+            self._authenticationPayload.auth.scope.domain = {name:self.options.projectDomainName};
+          }
+        } else {
+          if (self.options.projectDomainId) {
+            self._authenticationPayload.auth.scope.project.domain = {id:self.options.projectDomainId};
+          } else if(self.options.projectDomainName) {
+            self._authenticationPayload.auth.scope.project.domain = {name:self.options.projectDomainName};
+          }
         }
       }
-    };
-  }
-  // Token and tenant are also valid inputs
-  else if (self.options.token && (self.options.tenantId || self.options.tenantName)) {
-    self._authenticationPayload = {
-      auth: {
-        token: {
-          id: self.options.token
+    }
+    // Token and tenant are also valid inputs
+    else if (self.options.token && (self.options.tenantId || self.options.tenantName)) {
+      self._authenticationPayload = {
+        auth: {
+          identity : {
+            methods : ['token'],
+            token: {
+              id: self.options.token
+            }
+          }
         }
-      }
-    };
+      };
+    }
+  } else {
+    // setup our inputs for authorization
+    if (self.options.password && self.options.username) {
+      self._authenticationPayload = {
+        auth: {
+          passwordCredentials: {
+            username: self.options.username,
+            password: self.options.password
+          }
+        }
+      };
+    }
+    // Token and tenant are also valid inputs
+    else if (self.options.token && (self.options.tenantId || self.options.tenantName)) {
+      self._authenticationPayload = {
+        auth: {
+          token: {
+            id: self.options.token
+          }
+        }
+      };
+    }
+    // Are we filtering down by a tenant?
+    if (self.options.tenantId) {
+      self._authenticationPayload.auth.tenantId = self.options.tenantId;
+    }
+    else if (self.options.tenantName) {
+      self._authenticationPayload.auth.tenantName = self.options.tenantName;
+    }
   }
 };
 
@@ -265,25 +346,36 @@ Identity.prototype._buildAuthenticationPayload = function () {
  * @param {object}    data      the raw response from the identity call
  * @private
  */
-Identity.prototype._parseIdentityResponse = function (data) {
+Identity.prototype._parseIdentityResponse = function (data, headers) {
   var self = this;
 
   if (!data) {
     throw new Error('missing required arguments!');
   }
+  if (self.options.keystoneAuthVersion === 'v3') {
+    self.token = {
+      id: headers['x-subject-token'],
+      expires: new Date(data.token.expires_at),
+      issued_at: new Date(data.token.issued_at),
+      tenant: {id: data.token.project.id, name: data.token.project.name}
+    };
+    self.user = data.token.user;
+    if (self.useServiceCatalog) {
+      self.serviceCatalog = new ServiceCatalog(data.token.catalog);
+    }
+  } else {
+    if (data.access.token) {
+      self.token = data.access.token;
+      self.token.expires = new Date(self.token.expires);
+    }
 
-  if (data.access.token) {
-    self.token = data.access.token;
-    self.token.expires = new Date(self.token.expires);
+    if (self.useServiceCatalog && data.access.serviceCatalog) {
+      self.serviceCatalog = new ServiceCatalog(data.access.serviceCatalog);
+    }
+
+    self.user = data.access.user;
   }
-
-  if (self.useServiceCatalog && data.access.serviceCatalog) {
-     self.serviceCatalog = new ServiceCatalog(data.access.serviceCatalog);
-  }
-
-  self.user = data.access.user;
   self.raw = data;
-
 };
 
 Identity.prototype.getServiceEndpointUrl = function (options) {
@@ -299,3 +391,6 @@ Identity.prototype.getServiceEndpointUrl = function (options) {
     return this.options.url;
   }
 };
+
+
+

--- a/lib/pkgcloud/openstack/context/service.js
+++ b/lib/pkgcloud/openstack/context/service.js
@@ -2,6 +2,7 @@
  * service.js: Service model
  *
  * (C) 2013 Rackspace, Ken Perkins
+ * (C) 2015 IBM Corp.
  * MIT LICENSE
  *
  */
@@ -67,14 +68,23 @@ Service.prototype.getEndpointUrl = function (options) {
   if (options.serviceType.toLowerCase() !== this.type.toLowerCase()) {
     return '';
   }
+  //since we don't know if this is a v2 or v3 catalog, check if the "interface" field is set on an endpoint, if so, we're v3
+  if (self.endpoints && self.endpoints.length > 0 && self.endpoints[0]['interface'] !== undefined) {
+      self.v3 = true;
+  }
 
   if (options.region) {
     _.each(self.endpoints, function (endpoint) {
       if (!endpoint.region || !matchRegion(endpoint.region, options.region)) {
         return;
       }
-
-      url = getUrl(endpoint);
+      if (self.v3 === true) {
+        if (endpointMatchDesiredInterface(endpoint)) {
+          url = endpoint.url;
+        }
+      } else {
+        url = getUrl(endpoint);
+      }
     });
   }
   else {
@@ -109,6 +119,23 @@ Service.prototype.getEndpointUrl = function (options) {
       ? endpoint.internalURL
       : ((typeof options.useAdmin === 'boolean' && options.useAdmin && endpoint.adminURL) ?
         endpoint.adminURL : endpoint.publicURL);
+  }
+
+  /**
+   * endpointMatchDesiredInterface
+   *
+   * @description determine if the endpoint interface matches the desired interface
+   * @param {object} endpoint
+   * @returns {Boolean}
+   */
+  function endpointMatchDesiredInterface(endpoint) {
+    var interfaceToUse = 'public';
+    if (options.useInternal === true) {
+      interfaceToUse = 'internal';
+    } else if (options.useAdmin === true) {
+      interfaceToUse = 'admin';
+    }
+    return endpoint['interface'] === interfaceToUse;
   }
 
   if (!url) {


### PR DESCRIPTION
OpenStack updated Keystone to V3 and it contains a number of changes that should be addressed via pkgcloud.
http://docs.openstack.org/developer/keystone/http-api.html

client.js
- A goal is to maintain backwards compatibility with v2.
- keystoneAuthVersion is used to default to v2 if a version is not specified

identity.js
- The new path for obtaining the token is v3/auth/tokens instead of v2.0/tokens.
- Authentication in v3 now happens against domains
- The token is returned in the x-subject-token header

service.js
- In V3 the format was changed for how endpoints and interfaces are used. On returning endpoints, an object is created for each interface type now.