### PR TITLE
Support large file downloading by using buffers with the request library

### DIFF
--- a/lib/pkgcloud/core/base/client.js
+++ b/lib/pkgcloud/core/base/client.js
@@ -84,6 +84,10 @@ Client.prototype._request = function (options, callback) {
     requestOptions.body = options.body;
   }
 
+  if (options.encoding || options.encoding === null) {
+    requestOptions.encoding = options.encoding;
+  }
+
   if (options.container) {
     requestOptions.signingUrl = '/' + options.container + '/';
 

--- a/lib/pkgcloud/openstack/storage/client/files.js
+++ b/lib/pkgcloud/openstack/storage/client/files.js
@@ -203,7 +203,8 @@ exports.download = function (options, callback) {
     container: container,
     path: options.remote,
     download: true,
-    headers: options.headers
+    headers: options.headers,
+    encoding: null
   }, success);
 
   if (inputStream) {


### PR DESCRIPTION
I am not sure if this is the appropriate level to make this change, but it is a change that needs made asap.  Without explicitly setting the encoding, the entire response body is converted to a js string, which  has a size limit of 268435440 bytes.

(My first pull to this repo, so be easy on me :) I'll gladly make any changes to get this functionality in, as it is absolutely essential.)