### PR TITLE
Add OpenStack auth support for userId.  Provides v2 clients the ability…

### DIFF
--- a/lib/pkgcloud/openstack/client.js
+++ b/lib/pkgcloud/openstack/client.js
@@ -89,6 +89,9 @@ Client.prototype._getIdentityOptions = function() {
   else if (this.config.tenantName) {
     options.tenantName = this.config.tenantName;
   }
+  if (this.config.userId) {
+    options.userId = this.config.userId;
+  }
   if (typeof this.config.useServiceCatalog === 'boolean') {
     options.useServiceCatalog = this.config.useServiceCatalog;
   }

--- a/lib/pkgcloud/openstack/context/identity.js
+++ b/lib/pkgcloud/openstack/context/identity.js
@@ -244,6 +244,17 @@ Identity.prototype._buildAuthenticationPayload = function () {
       }
     };
   }
+  else if (self.options.password && self.options.userId && self.options.tenantId) {
+    self._authenticationPayload = {
+        auth: {
+          tenantId: self.options.tenantId,
+          passwordCredentials: {
+            userId: self.options.userId,
+            password: self.options.password
+          }
+        }
+    };
+  }
   // Token and tenant are also valid inputs
   else if (self.options.token && (self.options.tenantId || self.options.tenantName)) {
     self._authenticationPayload = {


### PR DESCRIPTION
… to participate in clouds using domains.

Includes support for this auth payload:
auth: {
      tenantId: "2598f527914c4344ba7a364a85b12f42",
      passwordCredentials: {
            userId: "2258f527914c4344ba7a364a85b12e84,
            password: "secretsecret"
       }
}

This auth method is missing from Identity v2.0 spec.  Work is in progress to get it added.
See: https://review.openstack.org/#/c/240126/