### PR TITLE
[storage] Add temporary url functionality to openstack storage

### DIFF
--- a/lib/pkgcloud/openstack/storage/client/account.js
+++ b/lib/pkgcloud/openstack/storage/client/account.js
@@ -1,0 +1,101 @@
+var crypto = require('crypto');
+
+/**
+ * client.getTemporaryUrlKey
+ *
+ * @description get the previously set temporaryUrl key on the current account
+ *
+ * @param callback
+ */
+exports.getTemporaryUrlKey = function (callback) {
+  var self = this;
+
+  this._request({
+    method: 'HEAD'
+  }, function (err, body, res){
+    if(err) {
+      return callback(err);
+    }
+
+    var temporaryUrlKey = res.headers[self.ACCOUNT_META_PREFIX + 'temp-url-key'];
+    callback(null, temporaryUrlKey);
+  });
+
+};
+
+/**
+ * client.setTemporaryUrlKey
+ *
+ * @description set a temporaryUrl key on the current account
+ *
+ * @param {String}     key     the secret key to be used in hmac signing temporary urls
+ * @param callback
+ */
+exports.setTemporaryUrlKey = function (key, callback) {
+  if(!key){
+    return process.nextTick(function(){
+      callback(new Error('A temporary URL key must be provided'));
+    });
+  }
+
+  this._request({
+    method: 'POST',
+    headers: {
+      'x-account-meta-temp-url-key': key
+    }
+  }, function(err){
+    callback(err);
+  });
+};
+
+/**
+ * client.generateTempUrl
+ *
+ * @description create a temporary url for GET/PUT to a cloud files container
+ *
+ * @param {String|object}     container     the container or container name for the url
+ * @param {String|object}     file          the file or fileName for the url
+ * @param {String}            method        either GET or PUT
+ * @param {Number}            time          expiry for the url in seconds (from now)
+ * @param {String}            key           the secret key to be used for signing the url
+ * @param callback
+ */
+exports.generateTempUrl = function(container, file, method, time, key, callback) {
+  var containerName = container instanceof this.models.Container ? container.name : container,
+    fileName = file instanceof this.models.File ? file.name : file,
+    time = typeof time === 'number' ? time : parseInt(time),
+    self = this,
+    split = '/v1';
+
+  function createUrl() {
+    // construct our hmac signature
+    var expiry = parseInt(new Date().getTime() / 1000) + time,
+      url = self._getUrl({
+        container: containerName,
+        path: fileName
+      }),
+      hmac_body = method.toUpperCase() + '\n' + expiry + '\n' + split + url.split(split)[1];
+
+      var hash = crypto.createHmac('sha1', key).update(hmac_body).digest('hex');
+
+      callback(null, url + '?temp_url_sig=' + hash + '&temp_url_expires=' + expiry);
+  }
+
+  // We have to be authed to make sure we have the service catalog
+  // this is required to validate the service url
+
+  if (!this._isAuthorized()) {
+    this.auth(function(err) {
+      if (err) {
+        callback(err);
+        return;
+      }
+
+      createUrl();
+    });
+
+    return;
+  }
+
+  createUrl();
+};

--- a/lib/pkgcloud/openstack/storage/client/index.js
+++ b/lib/pkgcloud/openstack/storage/client/index.js
@@ -27,6 +27,7 @@ var Client = exports.Client = function (options) {
 
   _.extend(this, require('./containers'));
   _.extend(this, require('./files'));
+  _.extend(this, require('./account'));
 
   this.serviceType = 'object-store';
 };

--- a/lib/pkgcloud/openstack/storage/storageClient.js
+++ b/lib/pkgcloud/openstack/storage/storageClient.js
@@ -15,6 +15,7 @@ const CONTAINER_META_PREFIX = 'x-container-meta-';
 const CONTAINER_REMOVE_META_PREFIX = 'x-remove-container-meta-';
 const OBJECT_META_PREFIX = 'x-object-meta-';
 const OBJECT_REMOVE_META_PREFIX = 'x-object-remove-meta-';
+const ACCOUNT_META_PREFIX = 'x-account-meta-';
 
 var Client = exports.StorageClient = function () {
   this.serviceType = 'object-store';
@@ -87,9 +88,11 @@ Client.prototype.deserializeMetadata = function (prefix, metadata) {
   return deserializedMetadata;
 };
 
+
+
 Client.prototype.CONTAINER_META_PREFIX = CONTAINER_META_PREFIX;
 Client.prototype.CONTAINER_REMOVE_META_PREFIX = CONTAINER_REMOVE_META_PREFIX;
 Client.prototype.OBJECT_META_PREFIX = OBJECT_META_PREFIX;
 Client.prototype.OBJECT_REMOVE_META_PREFIX = OBJECT_REMOVE_META_PREFIX;
-
+Client.prototype.ACCOUNT_META_PREFIX = ACCOUNT_META_PREFIX;
 

--- a/test/openstack/storage/temp-url-test.js
+++ b/test/openstack/storage/temp-url-test.js
@@ -1,0 +1,195 @@
+'use strict';
+
+var should = require('should'),
+  async = require('async'),
+  helpers = require('../../helpers'),
+  hock = require('hock'),
+  http = require('http'),
+  mock = !!process.env.MOCK;
+
+var setupSetTemporaryUrlKeyMock, setupGetTemporaryUrlKeyMock, setupGenerateTempUrlKeyMock;
+
+describe('pkgcloud/openstack/storage', function(){
+  var client, authHockInstance, hockInstance,
+    authServer, server;
+
+    beforeEach(function (done) {
+      client = helpers.createClient('openstack', 'storage');
+
+      if(!mock) {
+        return done();
+      }
+
+      hockInstance = hock.createHock({ throwOnUnmatched: false });
+      authHockInstance = hock.createHock();
+
+      server = http.createServer(hockInstance.handler);
+      authServer = http.createServer(authHockInstance.handler);
+
+      async.parallel([
+        function (next) {
+          server.listen(12345, next);
+        },
+        function (next) {
+          authServer.listen(12346, next);
+        }
+      ], done);
+
+    });
+
+    afterEach(function (done) {
+      client = null;
+      if (!mock) {
+        return done();
+      }
+
+      async.parallel([
+        function (next) {
+          server.close(next);
+        },
+        function (next) {
+          authServer.close(next);
+        }
+      ], done);
+
+    });
+
+    it('the client.getTemporaryUrlKey() method should return the temporary url key', function(done){
+      if(mock) {
+        setupGetTemporaryUrlKeyMock(client, {
+          authServer: authHockInstance,
+          server: hockInstance
+        });
+      }
+
+      client.getTemporaryUrlKey(function (err, temporaryUrlKey) {
+        should.not.exist(err);
+        should.exist(temporaryUrlKey);
+
+        authHockInstance && authHockInstance.done();
+        hockInstance && hockInstance.done();
+
+        done();
+      });
+    });
+
+    it('the client.setTemporaryUrlKey() method should have the proper header', function(done){
+      if(mock) {
+        setupSetTemporaryUrlKeyMock(client, {
+          authServer: authHockInstance,
+          server: hockInstance
+        });
+      }
+
+      client.setTemporaryUrlKey('54321', function (err) {
+        should.not.exist(err);
+
+        authHockInstance && authHockInstance.done();
+        hockInstance && hockInstance.done();
+
+        done();
+      });
+    });
+
+    it('the client.generateTempUrl() method should return the temporary url', function(done){
+      if(mock) {
+        setupGenerateTempUrlKeyMock(client, {
+          authServer: authHockInstance,
+          server: hockInstance
+        });
+      }
+
+      client.generateTempUrl('container', 'file', 'GET', 60, '12345', function (err, temporaryUrl) {
+        should.not.exist(err);
+        should.exist(temporaryUrl);
+
+        authHockInstance && authHockInstance.done();
+        hockInstance && hockInstance.done();
+
+        done();
+      });
+    });
+});
+
+setupGetTemporaryUrlKeyMock = function (client, servers) {
+  servers.authServer
+  .post('/v2.0/tokens', {
+    auth: {
+      passwordCredentials: {
+        username: 'MOCK-USERNAME',
+        password: 'MOCK-PASSWORD'
+      }
+    }
+  })
+  .replyWithFile(200, __dirname + '/../../fixtures/openstack/initialToken.json')
+  .get('/v2.0/tenants')
+  .replyWithFile(200, __dirname + '/../../fixtures/openstack/tenantId.json')
+  .post('/v2.0/tokens', {
+    auth: {
+      passwordCredentials: {
+        username: 'MOCK-USERNAME',
+        password: 'MOCK-PASSWORD'
+      },
+      tenantId: '72e90ecb69c44d0296072ea39e537041'
+    }
+  })
+  .reply(200, helpers.getOpenstackAuthResponse());
+
+  servers.server
+  .head('/v1/MossoCloudFS_00aa00aa-aa00-aa00-aa00-aa00aa00aa00')
+  .reply(200, null, {'x-account-meta-temp-url-key': '12345'});
+};
+
+setupSetTemporaryUrlKeyMock = function (client, servers) {
+  servers.authServer
+  .post('/v2.0/tokens', {
+    auth: {
+      passwordCredentials: {
+        username: 'MOCK-USERNAME',
+        password: 'MOCK-PASSWORD'
+      }
+    }
+  })
+  .replyWithFile(200, __dirname + '/../../fixtures/openstack/initialToken.json')
+  .get('/v2.0/tenants')
+  .replyWithFile(200, __dirname + '/../../fixtures/openstack/tenantId.json')
+  .post('/v2.0/tokens', {
+    auth: {
+      passwordCredentials: {
+        username: 'MOCK-USERNAME',
+        password: 'MOCK-PASSWORD'
+      },
+      tenantId: '72e90ecb69c44d0296072ea39e537041'
+    }
+  })
+  .reply(200, helpers.getOpenstackAuthResponse());
+
+  servers.server
+  .post('/v1/MossoCloudFS_00aa00aa-aa00-aa00-aa00-aa00aa00aa00', null, {'x-account-meta-temp-url-key': '54321'})
+  .reply(201);
+};
+
+setupGenerateTempUrlKeyMock = function (client, servers) {
+  servers.authServer
+  .post('/v2.0/tokens', {
+    auth: {
+      passwordCredentials: {
+        username: 'MOCK-USERNAME',
+        password: 'MOCK-PASSWORD'
+      }
+    }
+  })
+  .replyWithFile(200, __dirname + '/../../fixtures/openstack/initialToken.json')
+  .get('/v2.0/tenants')
+  .replyWithFile(200, __dirname + '/../../fixtures/openstack/tenantId.json')
+  .post('/v2.0/tokens', {
+    auth: {
+      passwordCredentials: {
+        username: 'MOCK-USERNAME',
+        password: 'MOCK-PASSWORD'
+      },
+      tenantId: '72e90ecb69c44d0296072ea39e537041'
+    }
+  })
+  .reply(200, helpers.getOpenstackAuthResponse());
+};


### PR DESCRIPTION
This pull requests adds temporary url functionality to openstack storage.  It is modeled off of the code written specifically for the rackspace provider as well as the similar implementation from [pyrax](https://github.com/rackspace/pyrax).

With this update, you can both set and get the temporary url key associated with your account in addition to generating the temporary url itself.

Because the rackspace storage provider uses the openstack provider's storageClient object, it was necessary to add the additional file file `account.js` along with the corresponding extend in `client/index.js`.

There were no previous tests written for openstack storage so I have created a few simple ones for this new functionality.  Due to my unfamiliarity with `hock` they may be more verbose than is needed but they do seem to model the functionality as expected.  **Note**: `npm test` currently fails (as seen in the failed travis builds) due to some issue with [blanket](https://github.com/alex-seville/blanket).  After removing the `blanket` integration, tests run but there are 14 failing, none of which dealt with openstack storage.  Both of these concerns were outside of the scope of this pull request so I did not investigate them too deeply.  The newly added tests all complete successfully.

This pull request should close #422 and and possibly #376
