### PR TITLE
[fix] aws storage client

### DIFF
--- a/lib/pkgcloud/amazon/storage/client/files.js
+++ b/lib/pkgcloud/amazon/storage/client/files.js
@@ -52,6 +52,19 @@ exports.upload = function (options) {
     Key: options.remote instanceof base.File ? options.remote.name : options.remote
   };
 
+  //
+  // Allow for configuration of upload parameters
+  //
+  var uploadOptions = {};
+
+  if (options.concurrency || options.queueSize) {
+    uploadOptions.queueSize = options.concurrency || options.queueSize;
+  }
+
+  if (options.partSize) {
+    uploadOptions.partSize = options.partSize;
+  }
+
   if (options.cacheControl) {
     s3Options.CacheControl = options.cacheControl;
   }
@@ -74,24 +87,22 @@ exports.upload = function (options) {
     s3Options.ServerSideEncryption = options.ServerSideEncryption;
   }
 
-  var proxyStream = through(),
-    writableStream = self.s3Stream.upload(s3Options);
+  var proxyStream = through();
 
-  // we need a proxy stream so we can always return a file model
-  // via the 'success' event
-  writableStream.on('uploaded', function(details) {
+  s3Options.Body = proxyStream;
+  var upload = this.s3.upload(s3Options, uploadOptions);
+
+  //
+  // To allow aborting of upload if we want
+  //
+  proxyStream.abort = upload.abort.bind(upload);
+
+  upload.send(function (err, details) {
+    if (err) return proxyStream.emit('error', err);
+    // we need a proxy stream so we can always return a file model
+    // via the 'success' event
     proxyStream.emit('success', new storage.File(self, details));
   });
-
-  writableStream.on('error', function(err) {
-    proxyStream.emit('error', err);
-  });
-
-  writableStream.on('data', function (chunk) {
-    proxyStream.emit('data', chunk);
-  });
-
-  proxyStream.pipe(writableStream);
 
   return proxyStream;
 };

--- a/lib/pkgcloud/amazon/storage/client/index.js
+++ b/lib/pkgcloud/amazon/storage/client/index.js
@@ -7,7 +7,6 @@
 
 var util = require('util'),
     AWS = require('aws-sdk'),
-    s3Stream = require('s3-upload-stream'),
     amazon = require('../../client'),
     _ = require('lodash');
 
@@ -18,9 +17,6 @@ var Client = exports.Client = function (options) {
   _.extend(this, require('./files'));
 
   this.s3 = new AWS.S3(this._awsConfig);
-
-  // configure the s3Stream
-  this.s3Stream = s3Stream(this.s3);
 };
 
 util.inherits(Client, amazon.Client);

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   ],
   "dependencies": {
     "async": "0.9.x",
-    "aws-sdk": "^2.2.43",
+    "aws-sdk": "~2.7.17",
     "errs": "0.3.x",
     "eventemitter2": "0.4.x",
     "fast-json-patch": "0.5.x",
@@ -67,7 +67,6 @@
     "mime": "1.2.x",
     "qs": "1.2.x",
     "request": "2.40.x",
-    "s3-upload-stream": "~1.0.7",
     "through2": "0.6.x",
     "url-join": "0.0.x",
     "xml2js": "0.1.x"


### PR DESCRIPTION
- Update the aws-sdk
- Use built in upload rather than external module
- expose concurrency/queueSize and partSize configurability
- Add ability to abort upload