### PR TITLE
Fix typo in createSecurityGroup

### DIFF
--- a/lib/pkgcloud/openstack/network/client/securityGroups.js
+++ b/lib/pkgcloud/openstack/network/client/securityGroups.js
@@ -102,7 +102,7 @@ exports.createSecurityGroup = function (securityGroup, callback) {
   this._request(createSecurityGroupOpts, function (err,body) {
     return err
       ? callback(err)
-      : callback(err, new self.models.SecurityGroup(self, body.securityGroup));
+      : callback(err, new self.models.SecurityGroup(self, body.security_group));
   });
 };
 


### PR DESCRIPTION
Issue #454. The typo caused the response from openstack to createSecurityGroup not to be passed on to the user.