### PR TITLE
Patch openstack context service and serviceCatalog to support OVH cloud storage API

### DIFF
--- a/lib/pkgcloud/openstack/context/service.js
+++ b/lib/pkgcloud/openstack/context/service.js
@@ -75,6 +75,8 @@ Service.prototype.getEndpointUrl = function (options) {
 
   if (options.region) {
     _.each(self.endpoints, function (endpoint) {
+      // In order to support OVH Cloud Storage API
+      if (!endpoint.region && endpoint.region_id) endpoint.region = endpoint.region_id;
       if (!endpoint.region || !matchRegion(endpoint.region, options.region)) {
         return;
       }

--- a/lib/pkgcloud/openstack/context/serviceCatalog.js
+++ b/lib/pkgcloud/openstack/context/serviceCatalog.js
@@ -27,7 +27,8 @@ var ServiceCatalog = function (catalog) {
     if (service.type === 'compute' && service.name === 'cloudServers') {
       return;
     }
-
+    // In order to support OVH Cloud Storage API
+    if (!service.name && service.id) service.name = service.id;
     self.services[service.name] = new Service(service);
   });
 };


### PR DESCRIPTION
I have added support to OVH Cloud Storage, which is Open Stack but with subtle changes.

The first is, there is no name for a service instead there is an id.
The second is, there is no region property on an endpoint but a region_id property.

I'm not sure that's the best way to patch those irregularities, let me know how you would handle them if you see something better suited for this situation.

Thanks