### PR TITLE
Amazon storage use native aws-sdk for uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## FUTURE
+
+* Amazon use native `aws-sdk` for `s3` uploads instead of `s3-upload-stream` module
+* Update the `aws-sdk` to `2.7.25`
+* Amazon storage client.upload - expose concurrency - `queueSize` and `partSize` configurability and add ability to abort an upload
+
 ## v1.3.0
 * OpenStack identity v3 (keystone) support, Issue [#367](//github.com/pkgcloud/pkgcloud/issues/367), [#477](//github.com/pkgcloud/pkgcloud/issues/477), PR [#461](//github.com/pkgcloud/pkgcloud/pull/461)
 * OpenStack cancel client download, Issue [#379](//github.com/pkgcloud/pkgcloud/issues/379), PR [#416](//github.com/pkgcloud/pkgcloud/pull/416)

--- a/docs/providers/amazon.md
+++ b/docs/providers/amazon.md
@@ -26,3 +26,29 @@ var client = require('pkgcloud').storage.createClient({
    region: 'us-west-2' // region
 });
 ```
+### File upload
+
+Whether s3 `multipart-upload` or `putObject` API  is used depends on the `partSize` option value and the size of file being uploaded.
+Single `putObject` request is made if an object being uploaded is not large enough. if the object size exceeds defined `partSize`, it uses `multipart-upload` API
+
+
+```Javascript
+var readableStream = fs.createReadStream('./path/to/file');
+
+var writableStream = client.upload({
+    queueSize: 1, // == default value
+    partSize: 5 * 1024 * 1024, // == default value of 5MB
+    container: 'web-static',
+    remote: 'image.jpg'
+});
+
+//writableStream.managedUpload === https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3/ManagedUpload.html
+// managedUpload object allows you to abort ongoing upload or track file upload progress.
+
+readableStream.pipe(writableStream)
+.on('success', function(file) {
+    console.log(file);
+}).on('error', function(err) {
+    console.log(err);
+});
+```

--- a/lib/pkgcloud/amazon/storage/client/files.js
+++ b/lib/pkgcloud/amazon/storage/client/files.js
@@ -74,24 +74,17 @@ exports.upload = function (options) {
     s3Options.ServerSideEncryption = options.ServerSideEncryption;
   }
 
-  var proxyStream = through(),
-    writableStream = self.s3Stream.upload(s3Options);
-
   // we need a proxy stream so we can always return a file model
   // via the 'success' event
-  writableStream.on('uploaded', function(details) {
-    proxyStream.emit('success', new storage.File(self, details));
-  });
+  var proxyStream = through();
 
-  writableStream.on('error', function(err) {
-    proxyStream.emit('error', err);
+  s3Options.Body = proxyStream;
+  self.s3.upload(s3Options, {queueSize: options.queueSize || 1}, function(err, data) {
+      if (err) {
+        return proxyStream.emit('error', err);
+      }
+        return proxyStream.emit('success', new storage.File(self, data));
   });
-
-  writableStream.on('data', function (chunk) {
-    proxyStream.emit('data', chunk);
-  });
-
-  proxyStream.pipe(writableStream);
 
   return proxyStream;
 };

--- a/lib/pkgcloud/amazon/storage/client/files.js
+++ b/lib/pkgcloud/amazon/storage/client/files.js
@@ -52,6 +52,11 @@ exports.upload = function (options) {
     Key: options.remote instanceof base.File ? options.remote.name : options.remote
   };
 
+  var s3Settings = {
+    queueSize: options.queueSize || 1,
+    partSize: options.partSize || 5 * 1024 * 1024
+  };
+
   if (options.cacheControl) {
     s3Options.CacheControl = options.cacheControl;
   }
@@ -74,17 +79,26 @@ exports.upload = function (options) {
     s3Options.ServerSideEncryption = options.ServerSideEncryption;
   }
 
+  // we need a writable stream because aws-sdk listens for an error event on writable
+  // stream and redirects it to the provided callback - without the writable stream
+  // the error would be emitted twice on the returned proxyStream
+  var writableStream = through();
   // we need a proxy stream so we can always return a file model
   // via the 'success' event
   var proxyStream = through();
 
-  s3Options.Body = proxyStream;
-  self.s3.upload(s3Options, {queueSize: options.queueSize || 1}, function(err, data) {
-      if (err) {
-        return proxyStream.emit('error', err);
-      }
-        return proxyStream.emit('success', new storage.File(self, data));
+  s3Options.Body = writableStream;
+
+  var managedUpload = self.s3.upload(s3Options, s3Settings, function(err, data) {
+    if (err) {
+      return proxyStream.emit('error', err);
+    }
+    return proxyStream.emit('success', new storage.File(self, data));
   });
+
+  proxyStream.managedUpload = managedUpload;
+
+  proxyStream.pipe(writableStream);
 
   return proxyStream;
 };

--- a/lib/pkgcloud/amazon/storage/client/index.js
+++ b/lib/pkgcloud/amazon/storage/client/index.js
@@ -7,7 +7,6 @@
 
 var util = require('util'),
     AWS = require('aws-sdk'),
-    s3Stream = require('s3-upload-stream'),
     amazon = require('../../client'),
     _ = require('lodash');
 
@@ -18,9 +17,6 @@ var Client = exports.Client = function (options) {
   _.extend(this, require('./files'));
 
   this.s3 = new AWS.S3(this._awsConfig);
-
-  // configure the s3Stream
-  this.s3Stream = s3Stream(this.s3);
 };
 
 util.inherits(Client, amazon.Client);

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   ],
   "dependencies": {
     "async": "0.9.x",
-    "aws-sdk": "^2.2.43",
+    "aws-sdk": "^2.7.25",
     "errs": "0.3.x",
     "eventemitter2": "0.4.x",
     "fast-json-patch": "0.5.x",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "mime": "1.2.x",
     "qs": "1.2.x",
     "request": "2.40.x",
-    "s3-upload-stream": "~1.0.7",
     "through2": "0.6.x",
     "url-join": "0.0.x",
     "xml2js": "0.1.x"

--- a/test/common/storage/base-test.js
+++ b/test/common/storage/base-test.js
@@ -292,7 +292,8 @@ providers.filter(function (provider) {
 
       if (mock) {
         //TODO make it work for google
-        if (['google'].indexOf(provider) !== -1) {
+        //TODO make it work for azure - no idea why it fails on node 0.10 (it passes for node 6.8)
+        if (['google', 'azure'].indexOf(provider) !== -1) {
           return done();
         }
         setupBigDataUploadStreamMock(provider, client, {
@@ -307,9 +308,7 @@ providers.filter(function (provider) {
         headers: {'x-amz-acl': 'public-read'}
       });
 
-      stream.on('error', function(err, response) {
-        should.not.exist(err);
-        should.not.exist(response);
+      stream.on('error', function(err) {
         done(err);
       });
 
@@ -334,7 +333,8 @@ providers.filter(function (provider) {
 
       if (mock) {
         //TODO make it work for google
-        if (['google'].indexOf(provider) !== -1) {
+        //TODO make it work for azure - no idea why it fails on node 0.10 (it passes for node 6.8)
+        if (['google', 'azure'].indexOf(provider) !== -1) {
           return done();
         }
         setupBigDataDownloadStreamMock(provider, client, {

--- a/test/common/storage/base-test.js
+++ b/test/common/storage/base-test.js
@@ -22,12 +22,12 @@ var fs = require('fs'),
     File = require('../../../lib/pkgcloud/core/storage/file').File,
     mock = !!process.env.MOCK,
     pkgcloud = require('../../../lib/pkgcloud'),
-    fillerama = fs.readFileSync(helpers.fixturePath('fillerama.txt'), 'utf8');
+    fillerama = fs.readFileSync(helpers.fixturePath('fillerama.txt'), 'utf8'),
     bigFillerama = fs.readFileSync(helpers.fixturePath('bigfile.raw'));
 
 // Declaring variables for helper functions defined later
 var setupCreateContainerMock, setupGetContainersMock, setupUploadStreamMock,
-    setupBigDataUploadStreamMock, setupDownloadStreamMock, setupGetFileMock,
+    setupBigDataUploadStreamMock, setupDownloadStreamMock, setupBigDataDownloadStreamMock, setupGetFileMock,
     setupGetFilesMock, setupRemoveFileMock, setupDestroyContainerMock,
     setupGetContainers2Mock;
 

--- a/test/common/storage/base-test.js
+++ b/test/common/storage/base-test.js
@@ -34,11 +34,7 @@ var setupCreateContainerMock, setupGetContainersMock, setupUploadStreamMock,
 providers.filter(function (provider) {
   return !!helpers.pkgcloud.providers[provider].storage;
 }).forEach(function (provider) {
-  var desc = describe;
-  //if (provider == 'amazon') {
-    //desc = describe.only.bind(describe);
-  //}
-  desc('pkgcloud/common/storage/base [' + provider + ']', function () {
+  describe('pkgcloud/common/storage/base [' + provider + ']', function () {
 
     var config = null;
 

--- a/test/common/storage/base-test.js
+++ b/test/common/storage/base-test.js
@@ -57,7 +57,9 @@ providers.filter(function (provider) {
       hockInstance = hock.createHock({ throwOnUnmatched: false });
       authHockInstance = hock.createHock();
 
-      server = http.createServer(hockInstance.handler);
+      server = http.createServer(function(req, res) {
+          hockInstance.handler.apply(this, arguments);
+      });
       authServer = http.createServer(authHockInstance.handler);
 
       // setup a filtering path for aws
@@ -584,11 +586,7 @@ setupUploadStreamMock = function (provider, client, servers) {
   }
   else if (provider === 'amazon') {
     servers.server
-      .post('/test-file.txt?uploads')
-      .reply(200, '<?xml version="1.0" encoding="UTF-8"?>\n<InitiateMultipartUploadResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Bucket>pkgcloud-test-container</Bucket><Key>test-file.txt</Key><UploadId>U4vzbMZVEkBOyxMPHMCu7nRSUw.eNLeqK0oYOPA6BeeiDSu6OTjrsMkkTsOFav3qCpgvIJluGWe_Yi.ypTVxEg--</UploadId></InitiateMultipartUploadResult>', {})
-      .put('/test-file.txt?partNumber=1&uploadId=U4vzbMZVEkBOyxMPHMCu7nRSUw.eNLeqK0oYOPA6BeeiDSu6OTjrsMkkTsOFav3qCpgvIJluGWe_Yi.ypTVxEg--', fillerama)
-      .reply(200, '<?xml version="1.0" encoding="UTF-8"?>\n\n<CompleteMultipartUploadResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Location>https://pkgcloud-test-container.s3.amazonaws.com/test-file.txt</Location><Bucket>pkgcloud-test-container</Bucket><Key>test-file.txt</Key><ETag>&quot;b2286fe4aac65809a1b7a053d07fc99f-1&quot;</ETag></CompleteMultipartUploadResult>')
-      .post('/test-file.txt?uploadId=U4vzbMZVEkBOyxMPHMCu7nRSUw.eNLeqK0oYOPA6BeeiDSu6OTjrsMkkTsOFav3qCpgvIJluGWe_Yi.ypTVxEg--', '<CompleteMultipartUpload xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Part><ETag>"b2286fe4aac65809a1b7a053d07fc99f-1"</ETag><PartNumber>1</PartNumber></Part></CompleteMultipartUpload>')
+      .put('/test-file.txt', fillerama)
       .reply(200);
 
   }

--- a/test/common/storage/base-test.js
+++ b/test/common/storage/base-test.js
@@ -59,9 +59,7 @@ providers.filter(function (provider) {
       hockInstance = hock.createHock({ throwOnUnmatched: false });
       authHockInstance = hock.createHock();
 
-      server = http.createServer(function(req, res) {
-          hockInstance.handler.apply(this, arguments);
-      });
+      server = http.createServer(hockInstance.handler);
       authServer = http.createServer(authHockInstance.handler);
 
       // setup a filtering path for aws

--- a/test/common/storage/base-test.js
+++ b/test/common/storage/base-test.js
@@ -320,7 +320,7 @@ providers.filter(function (provider) {
 
         context.bigFile = {
           name: 'bigfile.raw',
-          size: Buffer.byteLength(bigFillerama)
+          size: bigFillerama.length
         };
 
         done();
@@ -352,7 +352,7 @@ providers.filter(function (provider) {
       context.fileContentsSize = 0;
       stream.on('data', function (data) {
         context.fileContents.push(data);
-        context.fileContentsSize += data.byteLength;
+        context.fileContentsSize += data.length;
       });
 
       stream.on('error', function(err) {
@@ -360,7 +360,6 @@ providers.filter(function (provider) {
       });
 
       stream.on('end', function() {
-        //expect(Buffer.from(context.fileContents).equals(bigFillerama)).to.be.true;
         hockInstance && hockInstance.done();
 
         context.fileContents = Buffer.concat(context.fileContents,
@@ -368,7 +367,7 @@ providers.filter(function (provider) {
 
         //Compare byte by byte
         var original = bigFillerama.toString('ascii');
-        for (var i = 0; i < context.bigFile.size; i++) {
+        for (var i = 0; i < original.length; i++) {
           assert.equal(context.fileContents[i], original[i]);
         }
 

--- a/test/common/storage/base-test.js
+++ b/test/common/storage/base-test.js
@@ -34,7 +34,11 @@ var setupCreateContainerMock, setupGetContainersMock, setupUploadStreamMock,
 providers.filter(function (provider) {
   return !!helpers.pkgcloud.providers[provider].storage;
 }).forEach(function (provider) {
-  describe('pkgcloud/common/storage/base [' + provider + ']', function () {
+  var desc = describe;
+  //if (provider == 'amazon') {
+    //desc = describe.only.bind(describe);
+  //}
+  desc('pkgcloud/common/storage/base [' + provider + ']', function () {
 
     var config = null;
 
@@ -293,8 +297,8 @@ providers.filter(function (provider) {
     it('the upload() method with large file should succeed', function (done) {
 
       if (mock) {
-        //TODO make it work for rackspace
-        if (provider != 'amazon') {
+        //TODO make it work for google
+        if (['google'].indexOf(provider) !== -1) {
           return done();
         }
         setupBigDataUploadStreamMock(provider, client, {
@@ -310,71 +314,72 @@ providers.filter(function (provider) {
       });
 
       stream.on('error', function(err, response) {
-        console.log('==================+ERROR==================');
-        console.log(err);
         should.not.exist(err);
         should.not.exist(response);
         done();
       });
 
       stream.on('success', function(file) {
-        console.log('==================+SUCCESS==================');
         authHockInstance && authHockInstance.done();
         hockInstance && hockInstance.done();
         file.should.be.an.instanceof(File);
 
-        //context.file = {
-          //name: 'bigfile.raw',
-          //size: Buffer.byteLength(bigFillerama)
-        //};
+        context.bigFile = {
+          name: 'bigfile.raw',
+          size: Buffer.byteLength(bigFillerama)
+        };
 
         done();
       });
-      //console.log('*********************BUFFEFER*****************');
-      //console.log(bigFillerama.slice(0, 5*1024*1024).byteLength);
 
-      var file = fs.createReadStream(helpers.fixturePath('bigfile.raw'));
+      var file = fs.createReadStream(helpers.fixturePath('bigfile.raw'), {encoding: 'ascii'});
       file.pipe(stream);
     });
 
     it('the download() method with large file should succeed', function (done) {
 
       if (mock) {
-        return done();
-        // TODO mock these out
+        //TODO make it work for google
+        if (['google'].indexOf(provider) !== -1) {
+          return done();
+        }
+        setupBigDataDownloadStreamMock(provider, client, {
+          server: hockInstance,
+          authServer: authHockInstance
+        });
       }
 
       var stream = client.download({
         container: context.container,
-        remote: context.file.name
-      }, function (err, file) {
-
-        should.not.exist(err);
-        should.exist(file);
-        file.should.be.instanceOf(File);
-
-        file.name.should.equal(context.file.name);
-        file.size.should.equal(context.fileContentsSize);
-
-        context.fileContents = Buffer.concat(context.fileContents,
-          file.size);
-
-        // Compare byte by byte
-        var original = fs.readFileSync(helpers.fixturePath('bigfile.raw'));
-        for (var i = 0; i < file.size; i++) {
-          assert.equal(context.fileContents[i], original[i]);
-        }
-
-        done();
+        remote: context.bigFile.name
       });
 
       context.fileContents = [];
       context.fileContentsSize = 0;
       stream.on('data', function (data) {
         context.fileContents.push(data);
-        context.fileContentsSize += data.length;
+        context.fileContentsSize += data.byteLength;
       });
-      stream.end();
+
+      stream.on('error', function(err) {
+        return done(err);
+      });
+
+      stream.on('end', function() {
+        //expect(Buffer.from(context.fileContents).equals(bigFillerama)).to.be.true;
+        hockInstance && hockInstance.done();
+
+        context.fileContents = Buffer.concat(context.fileContents,
+          context.fileContentsSize).toString('ascii');
+
+        //Compare byte by byte
+        var original = bigFillerama.toString('ascii');
+        for (var i = 0; i < context.bigFile.size; i++) {
+          assert.equal(context.fileContents[i], original[i]);
+        }
+
+        return done();
+      });
     });
 
     it('the destroyContainer() method with container should succeed', function (done) {
@@ -634,7 +639,7 @@ setupUploadStreamMock = function (provider, client, servers) {
 setupBigDataUploadStreamMock = function (provider, client, servers) {
   if (provider === 'rackspace' || provider === 'openstack') {
     servers.server
-      .put('/v1/MossoCloudFS_00aa00aa-aa00-aa00-aa00-aa00aa00aa00/pkgcloud-test-container/bigfile.raw', bigFillerama)
+      .put('/v1/MossoCloudFS_00aa00aa-aa00-aa00-aa00-aa00aa00aa00/pkgcloud-test-container/bigfile.raw', bigFillerama.toString('ascii'))
       .reply(200)
       .head('/v1/MossoCloudFS_00aa00aa-aa00-aa00-aa00-aa00aa00aa00/pkgcloud-test-container/bigfile.raw?format=json')
       .reply(200, '', { 'content-length': bigFillerama.length + 2 });
@@ -643,25 +648,29 @@ setupBigDataUploadStreamMock = function (provider, client, servers) {
     servers.server
       .post('/bigfile.raw?uploads')
       .reply(200, '<?xml version="1.0" encoding="UTF-8"?>\n<InitiateMultipartUploadResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Bucket>pkgcloud-test-container</Bucket><Key>bigfile.raw</Key><UploadId>U4vzbMZVEkBOyxMPHMCu7nRSUw.eNLeqK0oYOPA6BeeiDSu6OTjrsMkkTsOFav3qCpgvIJluGWe_Yi.ypTVxEg--</UploadId></InitiateMultipartUploadResult>', {})
-      .put('/bigfile.raw?partNumber=1&uploadId=U4vzbMZVEkBOyxMPHMCu7nRSUw.eNLeqK0oYOPA6BeeiDSu6OTjrsMkkTsOFav3qCpgvIJluGWe_Yi.ypTVxEg--', bigFillerama.slice(0, 5*1024*1024))
+      .put('/bigfile.raw?partNumber=1&uploadId=U4vzbMZVEkBOyxMPHMCu7nRSUw.eNLeqK0oYOPA6BeeiDSu6OTjrsMkkTsOFav3qCpgvIJluGWe_Yi.ypTVxEg--', bigFillerama.slice(0, 5*1024*1024).toString('ascii'))
       .reply(200, '<?xml version="1.0" encoding="UTF-8"?>\n\n<CompleteMultipartUploadResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Location>https://pkgcloud-test-container.s3.amazonaws.com/bigfile.raw</Location><Bucket>pkgcloud-test-container</Bucket><Key>bigfile.raw</Key><ETag>&quot;b2286fe4aac65809a1b7a053d07fc99f-1&quot;</ETag></CompleteMultipartUploadResult>')
-      .put('/bigfile.raw?partNumber=2&uploadId=U4vzbMZVEkBOyxMPHMCu7nRSUw.eNLeqK0oYOPA6BeeiDSu6OTjrsMkkTsOFav3qCpgvIJluGWe_Yi.ypTVxEg--', bigFillerama.slice(5*1024*1024, 10*1024*1024))
-      .reply(200, '<?xml version="1.0" encoding="UTF-8"?>\n\n<CompleteMultipartUploadResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Location>https://pkgcloud-test-container.s3.amazonaws.com/bigfile.raw</Location><Bucket>pkgcloud-test-container</Bucket><Key>bigfile.raw</Key><ETag>&quot;b2286fe4aac65809a1b7a053d07fc99f-1&quot;</ETag></CompleteMultipartUploadResult>')
-      .post('/bigfile.raw?uploadId=U4vzbMZVEkBOyxMPHMCu7nRSUw.eNLeqK0oYOPA6BeeiDSu6OTjrsMkkTsOFav3qCpgvIJluGWe_Yi.ypTVxEg--', '<CompleteMultipartUpload xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Part><ETag>"b2286fe4aac65809a1b7a053d07fc99f-1"</ETag><PartNumber>1</PartNumber></Part><Part><ETag>"b2286fe4aac65809a1b7a053d07fc99f-1"</ETag><PartNumber>2</PartNumber></Part></CompleteMultipartUpload>')
-      .reply(200);
+      .put('/bigfile.raw?partNumber=2&uploadId=U4vzbMZVEkBOyxMPHMCu7nRSUw.eNLeqK0oYOPA6BeeiDSu6OTjrsMkkTsOFav3qCpgvIJluGWe_Yi.ypTVxEg--', bigFillerama.slice(5*1024*1024, 10*1024*1024).toString('ascii'))
+    .reply(200, '<?xml version="1.0" encoding="UTF-8"?>\n\n<CompleteMultipartUploadResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Location>https://pkgcloud-test-container.s3.amazonaws.com/bigfile.raw</Location><Bucket>pkgcloud-test-container</Bucket><Key>bigfile.raw</Key><ETag>&quot;b2286fe4aac65809a1b7a053d07fc99f-2&quot;</ETag></CompleteMultipartUploadResult>')
+    .post('/bigfile.raw?uploadId=U4vzbMZVEkBOyxMPHMCu7nRSUw.eNLeqK0oYOPA6BeeiDSu6OTjrsMkkTsOFav3qCpgvIJluGWe_Yi.ypTVxEg--', '<CompleteMultipartUpload xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Part><ETag>"b2286fe4aac65809a1b7a053d07fc99f-1"</ETag><PartNumber>1</PartNumber></Part><Part><ETag>"b2286fe4aac65809a1b7a053d07fc99f-2"</ETag><PartNumber>2</PartNumber></Part></CompleteMultipartUpload>')
+    .reply(200);
   }
   else if (provider === 'azure') {
     servers.server
-      .put('/pkgcloud-test-container/bigfile.raw?comp=block&blockid=block000000000000000', bigFillerama)
+      .put('/pkgcloud-test-container/bigfile.raw?comp=block&blockid=block000000000000000', bigFillerama.slice(0, 4*1024*1024).toString('ascii'))
       .reply(201, '', helpers.azureResponseHeaders({'content-md5': 'mw0KEVFFwT8SgYGK3Cu8vg=='}))
-      .put('/pkgcloud-test-container/bigfile.raw?comp=blocklist', '<?xml version="1.0" encoding="utf-8"?><BlockList><Latest>block000000000000000</Latest></BlockList>')
+      .put('/pkgcloud-test-container/bigfile.raw?comp=block&blockid=block000000000000001', bigFillerama.slice(4*1024*1024, 8*1024*1024).toString('ascii'))
+      .reply(201, '', helpers.azureResponseHeaders({'content-md5': 'mw0KEVFFwT8SgYGK3Cu8vg=='}))
+      .put('/pkgcloud-test-container/bigfile.raw?comp=block&blockid=block000000000000002', bigFillerama.slice(8*1024*1024).toString('ascii'))
+      .reply(201, '', helpers.azureResponseHeaders({'content-md5': 'mw0KEVFFwT8SgYGK3Cu8vg=='}))
+      .put('/pkgcloud-test-container/bigfile.raw?comp=blocklist', '<?xml version="1.0" encoding="utf-8"?><BlockList><Latest>block000000000000000</Latest><Latest>block000000000000001</Latest><Latest>block000000000000002</Latest></BlockList>')
       .reply(201, '', helpers.azureResponseHeaders({'content-md5': 'VuFw1xub9CF3KoozbZ3kZw=='}))
       .get('/pkgcloud-test-container/bigfile.raw')
-      .reply(200, bigFillerama, helpers.azureGetFileResponseHeaders({'content-length': bigFillerama.length + 2, 'content-type': 'text/plain'}));
+      .reply(200, bigFillerama.toString('ascii'), helpers.azureGetFileResponseHeaders({'content-length': bigFillerama.length + 2, 'content-type': 'text/plain'}));
   }
   else if (provider === 'hp') {
     servers.server
-      .put('/v1/HPCloudFS_00aa00aa-aa00-aa00-aa00-aa00aa00aa00/pkgcloud-test-container/bigfile.raw', bigFillerama)
+      .put('/v1/HPCloudFS_00aa00aa-aa00-aa00-aa00-aa00aa00aa00/pkgcloud-test-container/bigfile.raw', bigFillerama.toString('ascii'))
       .reply(200)
       .head('/v1/HPCloudFS_00aa00aa-aa00-aa00-aa00-aa00aa00aa00/pkgcloud-test-container/bigfile.raw?format=json')
       .reply(200, '', { 'content-length': bigFillerama.length + 2 });
@@ -695,6 +704,36 @@ setupDownloadStreamMock = function (provider, client, servers) {
     servers.server
       .get('/v1/HPCloudFS_00aa00aa-aa00-aa00-aa00-aa00aa00aa00/pkgcloud-test-container/test-file.txt')
       .reply(200, fillerama, { 'content-length': fillerama.length + 2});
+  }
+};
+
+setupBigDataDownloadStreamMock = function (provider, client, servers) {
+  if (provider === 'rackspace' || provider === 'openstack') {
+    servers.server
+      .get('/v1/MossoCloudFS_00aa00aa-aa00-aa00-aa00-aa00aa00aa00/pkgcloud-test-container/bigfile.raw')
+      .reply(200, bigFillerama.toString('ascii'));
+  }
+  else if (provider === 'amazon') {
+    servers.server
+      .get('/bigfile.raw')
+      .reply(200, bigFillerama.toString('ascii'));
+  }
+  else if (provider === 'azure') {
+    servers.server
+      .get('/pkgcloud-test-container/bigfile.raw')
+      .reply(200, bigFillerama.toString('ascii'), helpers.azureGetFileResponseHeaders({'content-type': 'text/plain'}));
+  }
+  else if (provider === 'google') {
+    servers.server
+      .get('/storage/v1/b/pkgcloud-test-container/o/bigfile.raw')
+      .reply(200, { mediaLink: 'http://localhost:12345/mediaLink' })
+      .get('/mediaLink')
+      .reply(200, bigFillerama.toString('ascii'));
+  }
+  else if (provider === 'hp') {
+    servers.server
+      .get('/v1/HPCloudFS_00aa00aa-aa00-aa00-aa00-aa00aa00aa00/pkgcloud-test-container/bigfile.raw')
+      .reply(200, bigFillerama.toString('ascii'));
   }
 };
 

--- a/test/common/storage/base-test.js
+++ b/test/common/storage/base-test.js
@@ -310,7 +310,7 @@ providers.filter(function (provider) {
       stream.on('error', function(err, response) {
         should.not.exist(err);
         should.not.exist(response);
-        done();
+        done(err);
       });
 
       stream.on('success', function(file) {

--- a/test/common/storage/upload-test.js
+++ b/test/common/storage/upload-test.js
@@ -152,7 +152,7 @@ setupUploadStreamError = function (provider, client, servers) {
   }
   else if (provider === 'amazon') {
     servers.server
-      .post('/test-file.txt?uploads')
+      .put('/test-file.txt', 'foo')
       .reply(400);
   }
   else if (provider === 'azure') {


### PR DESCRIPTION
* Update the aws-sdk
* Use `upload` method of native `aws-sdk` rather than external `s3-upload-stream` module
* expose concurrency - `queueSize` and `partSize` configurability for the `client.upload` method
* expose `managedUpload` object on returned stream which provides ability to abort upload or track upload progress
* Fixed download/upload tests for large files which have been  skipped till now.

Due to `aws-sdk`'s weird design, extra processing steps had to be added to preserve `client.upload` method behavior. (I refer to two proxy streams used in the `upload` method). 
Certainly not good solution... however it seems there is no better one. 

Some download/upload test tweaks had to be made due to behavior of `aws-sdk`'s `upload` method which makes one `putObject` request if an object being uploaded is not large enough. if the object size exceeds defined `partSize`, it uses multipart upload API.