### PR TITLE
Fix typo in openstack createSecurityGroupRule

### DIFF
--- a/lib/pkgcloud/openstack/network/client/securityGroupRules.js
+++ b/lib/pkgcloud/openstack/network/client/securityGroupRules.js
@@ -108,7 +108,7 @@ exports.createSecurityGroupRule = function (securityGroupRule, callback) {
   this._request(createSecurityGroupRuleOpts, function (err,body) {
     return err
       ? callback(err)
-      : callback(err, new self.models.SecurityGroupRule(self, body.securityGroupRule));
+      : callback(err, new self.models.SecurityGroupRule(self, body.security_group_rule));
   });
 };
 


### PR DESCRIPTION
Issue #556.

In lib/pkgcloud/openstack/network/client/securityGroupRules.js the createSecurityGroupRule code uses 'body.securityGroupRule' in the callback, this should be 'body.security_group_rule' ( line 111 ).

The respose from openstack is documented [here](http://developer.openstack.org/api-ref/networking/v2/?expanded=create-security-group-rule-detail#create-security-group-rule).