### PR TITLE
openstack/identity : auth without 'project' + validateToken : support of token admin

### DIFF
--- a/lib/pkgcloud/openstack/client.js
+++ b/lib/pkgcloud/openstack/client.js
@@ -49,7 +49,7 @@ var Client = exports.Client = function (options) {
 
   this.before.push(function (req) {
     req.headers = req.headers || {};
-    req.headers['x-auth-token'] = this._identity ? this._identity.token.id : this.config.authToken;
+    req.headers['x-auth-token'] = (this._identity && this._identity.token) ? this._identity.token.id : this.config.authToken;
   });
 
   this.before.push(function (req) {
@@ -270,8 +270,10 @@ Client.prototype._request = function (options, callback) {
 Client.prototype._isAuthorized = function () {
   var self = this,
       authorized = false;
-
-  if (!self._serviceUrl || !self._identity || !self._identity.token || !self._identity.token.id || !self._identity.token.expires) {
+  
+  if (self.config.authToken){
+      authorized = true;
+  }else if (!self._serviceUrl || !self._identity || !self._identity.token || !self._identity.token.id || !self._identity.token.expires) {
     authorized = false;
   }
   else if (self._identity.token.expires.getTime() - new Date().getTime() > self.config.earlyTokenTimeout) {

--- a/lib/pkgcloud/openstack/context/identity.js
+++ b/lib/pkgcloud/openstack/context/identity.js
@@ -353,12 +353,21 @@ Identity.prototype._parseIdentityResponse = function (data, headers) {
     throw new Error('missing required arguments!');
   }
   if (self.options.keystoneAuthVersion === 'v3') {
-    self.token = {
-      id: headers['x-subject-token'],
-      expires: new Date(data.token.expires_at),
-      issued_at: new Date(data.token.issued_at),
-      tenant: {id: data.token.project.id, name: data.token.project.name}
-    };
+   if(data.token.project) {
+        self.token = {
+            id: headers['x-subject-token'],
+            expires: new Date(data.token.expires_at),
+            issued_at: new Date(data.token.issued_at),
+            tenant: {id: data.token.project.id, name: data.token.project.name}
+        };
+    } else{
+        self.token = {
+            id: headers['x-subject-token'],
+            expires: new Date(data.token.expires_at),
+            issued_at: new Date(data.token.issued_at),
+            tenant: {}
+        };
+    }
     self.user = data.token.user;
     if (self.useServiceCatalog) {
       self.serviceCatalog = new ServiceCatalog(data.token.catalog);

--- a/lib/pkgcloud/openstack/identity/client/index.js
+++ b/lib/pkgcloud/openstack/identity/client/index.js
@@ -57,7 +57,7 @@ Client.prototype.validateToken = function (token, belongsTo, callback) {
   }
 
   var options = {
-    path: urlJoin('/v2.0/tokens', token)
+    uri: urlJoin(this.authUrl , '/v2.0/tokens', token)
   };
 
   if (belongsTo) {

--- a/test/openstack/identity/identity-test.js
+++ b/test/openstack/identity/identity-test.js
@@ -185,7 +185,32 @@ describe('pkgcloud/openstack/identity', function () {
           });
       });
     });
+it('user token should validate with only admin token', function(done) {
+      if (mock) {
+          var headers = {
+              'X-Auth-Token' :  'e93be67f91724754aeb9409c9c69d305'
+          };
+        adminHockInstance
+          .get('/v2.0/tokens/4bc7c5dabf3e4a49918683437d386b8a',headers)
+          .replyWithFile(200, __dirname + '/../../fixtures/openstack/validateToken-admin.json');
+      }
 
+
+      var adminClient = identity.createClient({
+        authUrl: 'http://localhost:12347',
+        authToken: 'e93be67f91724754aeb9409c9c69d305',
+        useServiceCatalog: false,
+        region: 'Calxeda-AUS1'
+      });
+
+
+      adminClient.validateToken('4bc7c5dabf3e4a49918683437d386b8a',
+          function (err, body) {
+            should.not.exist(err);
+            should.exist(body);
+            done();
+      });
+    });
     it('get the tenant info with admin token', function(done) {
       if (mock) {
         hockInstance


### PR DESCRIPTION
Hi
I propose this merge first to support an authentification when the response does not have a 'project' (identity version v3).
Second, I tried to use the function 'validateToken' but with an adminToken.  
in git@github.com:ISI-nc/pkgcloud.git, it seems there was a beginning of supporting authToken ( this.config.authToken).. so I changed the _isAuthorized() method in this case.

I added a testcase on validateToken, but the previous one doesn't seem to follow the behavior of the keystone API... 
I wonder if I correctly understood how validateToken was supposed to be used. 

thank you for your reply if I made some mistake
(ps: I intend to make other pull request to support the version v3 of identity)

