### PR TITLE
Add support for additional options for createContainer function

### DIFF
--- a/lib/pkgcloud/openstack/storage/client/containers.js
+++ b/lib/pkgcloud/openstack/storage/client/containers.js
@@ -105,6 +105,23 @@ exports.createContainer = function (options, callback) {
     createContainerOpts.headers = self.serializeMetadata(self.CONTAINER_META_PREFIX, options.metadata);
   }
 
+  var allowOptions = [
+    'X-Container-Read',
+    'X-Container-Sync-To',
+    'X-Container-Sync-Key',
+    'X-Container-Write',
+    'Content-Type'
+  ];
+
+  allowOptions.forEach(function(opt) {
+    if (options[opt] != null) {
+      if (createContainerOpts.headers == null) {
+        createContainerOpts.headers = {};
+      }
+      createContainerOpts.headers[opt] = options[opt];
+    }
+  });
+
   this._request(createContainerOpts, function (err) {
     return err
       ? callback(err)


### PR DESCRIPTION
Add support for additional options when creating a container. 
(Like changing read / write access)

`client.createContainer({
  name: 'test-name',
  'X-Container-Read': '.r:*'
}`

Would only allow read operations on our `test-name` container.