### PR TITLE
Fix openstack client multiple concurrent authentications issue

### DIFF
--- a/lib/pkgcloud/openstack/client.js
+++ b/lib/pkgcloud/openstack/client.js
@@ -70,6 +70,7 @@ var Client = exports.Client = function (options) {
   });
 
   this._serviceUrl = null;
+  this._pendingAuthentications = [];
 };
 
 util.inherits(Client, base.Client);
@@ -142,6 +143,18 @@ Client.prototype.successCodes = {
 };
 
 /**
+ * Client.handleAuthentications
+ *
+ * @description This function dispatches authentication callbacks
+ *
+ * @param arg
+ */
+Client.prototype.handleAuthentications = function (arg) {
+  var fns = this._pendingAuthentications.splice(0);
+  fns.forEach(fn => fn(arg));
+};
+
+/**
  * Client.auth
  *
  * @description This function handles the primary authentication for OpenStack
@@ -157,9 +170,19 @@ Client.prototype.auth = function (callback) {
     return;
   }
 
+  self._pendingAuthentications.push(callback);
+
+  if (self._isAuthenticating != null && self._isAuthenticating) {
+    return;
+  }
+
+  self._isAuthenticating = true;
+
   self._identity.authorize(function(err) {
+    self._isAuthenticating = false;
     if (err) {
-      return callback(err);
+      self.handleAuthentications(err);
+      return;
     }
 
     var options = {
@@ -176,15 +199,16 @@ Client.prototype.auth = function (callback) {
         serviceUrl: self._serviceUrl,
         options: options
       });
-
-      callback();
+      self.handleAuthentications();
+      return;
     }
     catch (e) {
       self.emit('log::error', 'Unable to select endpoint for service', {
         error: e.toString(),
         options: options
       });
-      callback(e);
+      self.handleAuthentications(e);
+      return;
     }
   });
 };


### PR DESCRIPTION
- Store pending authentication callbacks
- Only call `authorize` for the first query
- Dispatch callbacks once authentication is done