### PR TITLE
Add availability_zone option to create a server in a specific host on Openstack

### DIFF
--- a/docs/providers/openstack/compute.md
+++ b/docs/providers/openstack/compute.md
@@ -31,10 +31,12 @@ Options are as follows:
 
 ```js
 {
-  name: 'serverName', // required
-  flavor: 'flavor1',  // required
-  image: 'image1',    // required
-  personality: []     // optional
+  name: 'serverName',   // required
+  flavor: 'flavor1',    // required
+  image: 'image1',      // required
+  personality: []       // optional
+  metadata: '',         // optional
+  availability_zone: '' // optional
 }
 ```
 Returns the server in the callback `f(err, server)`

--- a/lib/pkgcloud/openstack/compute/client/servers.js
+++ b/lib/pkgcloud/openstack/compute/client/servers.js
@@ -146,7 +146,7 @@ exports.createServer = function createServer(details, callback) {
       method: 'POST',
       path: _urlPrefix,
       body: {
-        server: _.pick(details, ['name', 'metadata', 'personality'])
+        server: _.pick(details, ['name', 'metadata', 'personality','availability_zone'])
       }
     };
 


### PR DESCRIPTION
I'm in the project to develop a scheduler integrated with openstack. For this it is necessary to force to create an instance in a specific host. This pull-request has this target goal. And the following small changes have already solved the problem. With this, I believe that this possibility is useful for developers.
