### PR TITLE
Adding all_tenants to list of options for openstack getServers

### DIFF
--- a/lib/pkgcloud/openstack/compute/client/extensions/servers.js
+++ b/lib/pkgcloud/openstack/compute/client/extensions/servers.js
@@ -41,3 +41,20 @@ exports.stopServer = function (server, callback) {
         });
 };
 
+/**
+ *  client.resetServerState
+ *  
+ *  @description resets a server's state
+ *  
+ *  @param {String|Object}   server          The server ID or server to stop
+ *  @param {String}          state
+ *  @param {function}        callback
+ *  @returns {*}
+ **/
+exports.resetServerState = function (server, state, callback) {
+    return this._doServerAction(server,
+        {'os-resetState': { 'state': state }},
+        function (err) {
+            return callback(err);
+        });
+};

--- a/lib/pkgcloud/openstack/compute/client/servers.js
+++ b/lib/pkgcloud/openstack/compute/client/servers.js
@@ -90,6 +90,7 @@ exports.getServers = function getServers(options, callback) {
     'image',
     'flavor',
     'name',
+    'all_tenants',
     'status',
     'marker',
     'limit',


### PR DESCRIPTION
This is so we can query the list of all servers in all projects