### PR TITLE
[docs] Add the forcePathBucket configuration to doc example

### DIFF
--- a/docs/providers/amazon.md
+++ b/docs/providers/amazon.md
@@ -24,5 +24,6 @@ var client = require('pkgcloud').storage.createClient({
    keyId: 'your-access-key-id', // access key id
    key: 'your-secret-key-id', // secret key
    region: 'us-west-2' // region
+   forcePathBucket: false // use the sub-domain configuration by default, reflected as s3ForcePathStyle
 });
 ```


### PR DESCRIPTION
While trying to use s3proxy, the server kept crashing (ArrayIndexOutOfBoundsException) because the expected path was using `'addressing_style': 'path'`.
This expose the configuration that can be found here https://github.com/pkgcloud/pkgcloud/blob/master/lib/pkgcloud/amazon/client.js#L36 .