### PR TITLE
gh-546: Solving #546 (Azure InvalidHeaderValue) by changing constants to newer API version

### DIFF
--- a/lib/pkgcloud/azure/utils/constants.js
+++ b/lib/pkgcloud/azure/utils/constants.js
@@ -2045,7 +2045,7 @@ var Constants = {
     * @const
     * @type {string}
     */
-    TARGET_STORAGE_VERSION: '2011-08-18',
+    TARGET_STORAGE_VERSION: '2015-12-11',
 
     /**
     * The UserAgent header.

--- a/lib/pkgcloud/azure/utils/sharedkey.js
+++ b/lib/pkgcloud/azure/utils/sharedkey.js
@@ -53,7 +53,7 @@ SharedKey.prototype.signRequest = function (req) {
   req.headers['x-ms-version'] = HeaderConstants.TARGET_STORAGE_VERSION;
 
   if (!req.headers[HeaderConstants.CONTENT_LENGTH]) {
-    req.headers[HeaderConstants.CONTENT_LENGTH] = '0';
+    req.headers[HeaderConstants.CONTENT_LENGTH] = '1';
   }
 
   var stringToSign =


### PR DESCRIPTION
Solving #546 (Azure InvalidHeaderValue) by changing constants to newer API version.

- Changing Azure SharedKey `HeaderConstants.CONTENT_LENGTH` to `1`
- Changing Azure constant ` TARGET_STORAGE_VERSION` to `2015-12-11`