### PR TITLE
azure - update TARGET_STORAGE_VERSION

### DIFF
--- a/lib/pkgcloud/azure/utils/constants.js
+++ b/lib/pkgcloud/azure/utils/constants.js
@@ -2045,7 +2045,7 @@ var Constants = {
     * @const
     * @type {string}
     */
-    TARGET_STORAGE_VERSION: '2011-08-18',
+    TARGET_STORAGE_VERSION: '2014-02-14',
 
     /**
     * The UserAgent header.


### PR DESCRIPTION
Bug fix
## SCENARIO
Consider the following env variables are present and filled with valid values:
- `AZURE_ACCOUNT`  - account name
- `AZURE_KEY` - account access key
- `AZURE_MAIN_CONTAINER` - a valid but empty container
Consider a well initiated client:
```
const azure = require('pkgcloud').storage.createClient({
  provider: 'azure', 
  storageAccount: process.env.AZURE_ACCOUNT,
  storageAccessKey: process.env.AZURE_KEY
});
```
When I try to get files
```
azure.getFiles(process.env.AZURE_MAIN_CONTAINER, {}, console.log);1
```

## EXPECTED
I expect no error and empty list of files
```
null []
```
## FOUND
An error rejecting the storage target version
```
{ Error: azure Error (400): Bad Request
    at Request._callback (C:\ws\watchdox\file-svr\node_modules\pkgCloud\lib\pkgcloud\core\base\client.js:183:28)
    at Request.self.callback (C:\ws\watchdox\file-svr\node_modules\pkgCloud\node_modules\request\request.js:186:22)
    at emitTwo (events.js:126:13)
    at Request.emit (events.js:214:7)
    at Request.<anonymous> (C:\ws\watchdox\file-svr\node_modules\pkgCloud\node_modules\request\request.js:1163:10)
    at emitOne (events.js:116:13)
    at Request.emit (events.js:211:7)
    at IncomingMessage.<anonymous> (C:\ws\watchdox\file-svr\node_modules\pkgCloud\node_modules\request\request.js:1085:12)
    at Object.onceWrapper (events.js:313:30)
  name: 'Error',
  provider: 'azure',
  failCode: 'Bad Request',
  statusCode: 400,
  href: 'http://wdidops.blob.core.windows.net/wdi-dev-test?restype=container&comp=list',
  method: 'GET',
  headers:
   { 'content-length': '328',
     'content-type': 'application/xml',
     server: 'Microsoft-HTTPAPI/2.0',
     'x-ms-request-id': 'e2274b8f-d01e-0025-343a-2ecc1e000000',
     date: 'Tue, 07 Aug 2018 10:36:52 GMT',
     connection: 'close' },
  result:
   { err: '﻿<?xml version="1.0" encoding="utf-8"?><Error><Code>InvalidHeaderValue</Code><Message>The value for one of the HTTP headers is not in the correct format.\nRequestId:e2274b8f-d01e-0025-343a-2ecc1e000000\nTime:2018-08-07T10:36:52.2324257Z</Message><HeaderName>x-ms-version</HeaderName><HeaderValue>2011-08-18</HeaderValue></Error>' } }
```