### PR TITLE
Set Content-Type with google storage

### DIFF
--- a/docs/providers/google.md
+++ b/docs/providers/google.md
@@ -22,3 +22,26 @@ var client = require('pkgcloud').storage.createClient({
    projectId: 'eco-channel-658' // project id
 });
 ```
+
+
+## Uploading a file
+```Javascript
+var readStream = fs.createReadStream(<filepath>);
+
+var writeStream = client.upload({
+  container: <CONTAINER_NAME>,
+  remote: <filename>,
+  contentType: 'application/pdf' // optional
+});
+
+writeStream.on('error', function (err) {
+  console.error(err);
+});
+
+writeStream.on('success', function (file) {
+  console.log("Success!");
+});
+
+readStream.pipe(writeStream);
+```
+

--- a/lib/pkgcloud/google/storage/client/files.js
+++ b/lib/pkgcloud/google/storage/client/files.js
@@ -7,6 +7,7 @@
 
 var pkgcloud = require('../../../../../lib/pkgcloud'),
   through = require('through2'),
+  mime = require('mime'),
   storage = pkgcloud.providers.google.storage,
   _ = require('lodash');
 
@@ -39,15 +40,22 @@ exports.removeFile = function (container, file, callback) {
 exports.upload = function (options) {
   var self = this,
     bucket = this._getBucket(options),
-    file = this._getFile(bucket, options);
+    file = this._getFile(bucket, options),
+    uploadOptions = {};
 
   // check for deprecated calling with a callback
   if (typeof arguments[arguments.length - 1] === 'function') {
     self.emit('log::warn', 'storage.upload no longer supports calling with a callback');
   }
 
+  if (options.contentType) {
+    uploadOptions.contentType = options.contentType;
+  } else {
+    uploadOptions.contentType = mime.lookup(options.file || options.remote || options);
+  }
+
   var proxyStream = through(),
-    writableStream = file.createWriteStream();
+    writableStream = file.createWriteStream(uploadOptions);
 
   // we need a proxy stream so we can always return a file model
   // via the 'success' event


### PR DESCRIPTION
Content-Type will always be text/plain, which causes issues when trying to open the file if it isn't plaintext (such as a pdf). 

This fixes that by either looking up the mime type, or using the provided contentType.

Addresses Issue [634](https://github.com/pkgcloud/pkgcloud/issues/634)