### PR TITLE
Add support for Azure Storage Emulator

### DIFF
--- a/docs/providers/azure.md
+++ b/docs/providers/azure.md
@@ -142,6 +142,7 @@ client.createServer(options, function (err, server) {
 	* `protocol`: specifies the transport protocol for the endpoint.
 
 * `rdp.port`: (Optional. Windows servers only). The port to use for RDP on Windows servers.
+* `emulator`: (Optional) ignores location & account settings and uses [Azure Storage Emulator hardcoded settings](https://docs.microsoft.com/en-gb/azure/storage/common/storage-use-emulator#addressing-resources-in-the-storage-emulator).
 
 <br/>
 <a name="azure-manage-cert"></a>

--- a/docs/providers/azure.md
+++ b/docs/providers/azure.md
@@ -142,7 +142,7 @@ client.createServer(options, function (err, server) {
 	* `protocol`: specifies the transport protocol for the endpoint.
 
 * `rdp.port`: (Optional. Windows servers only). The port to use for RDP on Windows servers.
-* `emulator`: (Optional) ignores location & account settings and uses [Azure Storage Emulator hardcoded settings](https://docs.microsoft.com/en-gb/azure/storage/common/storage-use-emulator#addressing-resources-in-the-storage-emulator).
+* `emulator`: (Optional) enables support for the Azure emulator [Azure Storage Emulator settings](https://docs.microsoft.com/en-gb/azure/storage/common/storage-use-emulator#addressing-resources-in-the-storage-emulator), you still need to configure the credentials to what is expected by the emulator, e.g. account `devstoreaccount1`.
 
 <br/>
 <a name="azure-manage-cert"></a>

--- a/lib/pkgcloud/azure/storage/client/index.js
+++ b/lib/pkgcloud/azure/storage/client/index.js
@@ -58,7 +58,7 @@ Client.prototype._getUrl = function (options) {
   }
 
   if (this.config.emulator) {
-    return urlJoin('http://127.0.0.1:10000/devstoreaccount1', fragment);
+    return urlJoin(this.protocol + this.serversUrl, this.azureKeys.storageAccount, fragment);
   }
 
   return urlJoin(this.protocol + this.azureKeys.storageAccount + '.' + this.serversUrl + '/',

--- a/lib/pkgcloud/azure/storage/client/index.js
+++ b/lib/pkgcloud/azure/storage/client/index.js
@@ -57,7 +57,10 @@ Client.prototype._getUrl = function (options) {
     fragment = urlJoin(fragment, options.path);
   }
 
+  if (this.config.emulator) {
+    return urlJoin('http://127.0.0.1:10000/devstoreaccount1', fragment);
+  }
 
-  return urlJoin('http://' + this.azureKeys.storageAccount + '.' + this.serversUrl + '/',
+  return urlJoin(this.protocol + this.azureKeys.storageAccount + '.' + this.serversUrl + '/',
     fragment);
 };


### PR DESCRIPTION
https://docs.microsoft.com/en-gb/azure/storage/common/storage-use-emulator#addressing-resources-in-the-storage-emulator

This could help pave the way for using https://github.com/azure/azurite to test.

fixed the protocol handling while at it.

it still needs to be done for the Tables and Queues, if this is accepted I'll consider making the PR's for those as well.