### PR TITLE
Issue 526 Fixed

### DIFF
--- a/lib/pkgcloud/azure/storage/client/index.js
+++ b/lib/pkgcloud/azure/storage/client/index.js
@@ -58,6 +58,6 @@ Client.prototype._getUrl = function (options) {
   }
 
 
-  return urlJoin('http://' + this.azureKeys.storageAccount + '.' + this.serversUrl + '/',
+  return urlJoin(this.protocol + this.azureKeys.storageAccount + '.' + this.serversUrl + '/',
     fragment);
 };


### PR DESCRIPTION
Issue 526 Fixed
* this.protocol from client instance is used as the URL protocol as it should be
* That value can be set in "options" when the azure client is set (i.e. using loopback-component-storage just write "protocol": "https://" or "http://" and for other uses, is the analog. By default is "https://")
* The change is in just one line, no depth change was needed