### PR TITLE
Fix GCS upload

### DIFF
--- a/lib/pkgcloud/google/storage/client/files.js
+++ b/lib/pkgcloud/google/storage/client/files.js
@@ -7,7 +7,6 @@
 
 var pkgcloud = require('../../../../../lib/pkgcloud'),
   through = require('through2'),
-  mime = require('mime'),
   storage = pkgcloud.providers.google.storage,
   _ = require('lodash');
 
@@ -41,25 +40,19 @@ exports.upload = function (options) {
   var self = this,
     bucket = this._getBucket(options),
     file = this._getFile(bucket, options),
-    uploadOptions = {};
+    metadata = { contentType: options.contentType };
 
   // check for deprecated calling with a callback
   if (typeof arguments[arguments.length - 1] === 'function') {
     self.emit('log::warn', 'storage.upload no longer supports calling with a callback');
   }
 
-  if (options.contentType) {
-    uploadOptions.contentType = options.contentType;
-  } else {
-    uploadOptions.contentType = mime.getType(options.file || options.remote || options);
-  }
-
   var proxyStream = through(),
-    writableStream = file.createWriteStream(uploadOptions);
+    writableStream = file.createWriteStream({ metadata });
 
   // we need a proxy stream so we can always return a file model
   // via the 'success' event
-  writableStream.on('complete', function() {
+  writableStream.on('finish', function() {
     proxyStream.emit('success', new storage.File(self, file));
   });
 

--- a/lib/pkgcloud/google/storage/client/files.js
+++ b/lib/pkgcloud/google/storage/client/files.js
@@ -6,7 +6,6 @@
  */
 
 var pkgcloud = require('../../../../../lib/pkgcloud'),
-  through = require('through2'),
   storage = pkgcloud.providers.google.storage,
   _ = require('lodash');
 
@@ -47,22 +46,15 @@ exports.upload = function (options) {
     self.emit('log::warn', 'storage.upload no longer supports calling with a callback');
   }
 
-  var proxyStream = through(),
-    writableStream = file.createWriteStream({ metadata });
+  // GCS implicitly detects mime-type if none was implicitly given via options
+  var writableStream = file.createWriteStream({ metadata });
 
-  // we need a proxy stream so we can always return a file model
-  // via the 'success' event
+  // return a file model via the 'success' event
   writableStream.on('finish', function() {
-    proxyStream.emit('success', new storage.File(self, file));
+    writableStream.emit('success', new storage.File(self, file));
   });
 
-  writableStream.on('error', function(err) {
-    proxyStream.emit('error', err);
-  });
-
-  proxyStream.pipe(writableStream);
-
-  return proxyStream;
+  return writableStream;
 };
 
 /**

--- a/lib/pkgcloud/google/storage/client/files.js
+++ b/lib/pkgcloud/google/storage/client/files.js
@@ -60,10 +60,6 @@ exports.upload = function (options) {
     proxyStream.emit('error', err);
   });
 
-  writableStream.on('data', function(chunk) {
-    proxyStream.emit('data', chunk);
-  });
-
   proxyStream.pipe(writableStream);
 
   return proxyStream;


### PR DESCRIPTION
The `storage.upload()` for provider `google` fails with a `FILE_NO_UPLOAD` error:
```
{ Error: The uploaded data did not match the data from the server. As a precaution, the file has been deleted. To be sure the content is the same, you should try uploading the file again.
  [...]
  code: 'FILE_NO_UPLOAD',
}
```

This is because the `writableStream.on('data',` listener snatches data away from being passed to GCS. In my testings only 3 to 10 % of a ~300KB file reached the bucket. The `@google-cloud/storage` library throws the `FILE_NO_UPLOAD` error while checking the hash of the uploaded file against the hash of its fraction in GCS. Which is correct as contents do not match.
Removing the `.on('data'` listener fixed this issue. I think this emit is not really needed as the `proxyStream` of the amazon (S3) implementation does not emit a `data` event, either.

By the way I adapted the metadata to fit the scheme used in the [GCS docs](https://cloud.google.com/nodejs/docs/reference/storage/latest/File#createWriteStream) and let GCS detect the mime-type itself, if non given by the consumer.