### PR TITLE
ProxyStream should not emit event data from another stream: it doesn't respect the Readable Streams spec. Causes 'write after end' and infinite loops

### DIFF
--- a/lib/pkgcloud/openstack/storage/client/files.js
+++ b/lib/pkgcloud/openstack/storage/client/files.js
@@ -146,10 +146,6 @@ exports.upload = function (options) {
     proxyStream.emit('error', err);
   });
 
-  writableStream.on('data', function (chunk) {
-    proxyStream.emit('data', chunk);
-  });
-
   // we need a proxy stream so we can always return a file model
   // via the 'success' event
   proxyStream.pipe(writableStream);


### PR DESCRIPTION
```js
 writableStream.on('data', function (chunk) {	
    proxyStream.emit('data', chunk); // this will cause bugs!!!!
  });	

  proxyStream.pipe(writableStream);
```

The line above create "write after end" errors and infinite loops in node v12.4.0 for very simple test cases.

For instance:

```js
const proxyStream = client.upload({ container, remote });
proxyStream.on('error', (err) => { reject(err); });
proxyStream.on('success', () => { resolve(); });

const readStream = fs.createReadStream(source);
readStream.pipe(proxyStream);
```
**Problem 1:**  The event "data" will be emitted twice with the same chunk by `proxyStream`, once when the `proxyStream` releases it, and a second time when `writableStream` releases it. But when `proxyStream` emits an event originating from `writableStream`, "end" may already have been emitted. 

This is goes against the spec:

> The 'end' event will not be emitted unless the data is completely consumed. 
https://nodejs.org/api/stream.html#stream_event_end

See logging:

```shell
readStream data <Buffer 25 50 44 46 2d 31 2e 34 0a 25 c3 a4 c3 bc c3 b6 c3 9f 0a 32 20 30 20 6f 62 6a 0a 3c 3c 2f 4c 65 6e 67 74 68 20 33 20 30 20 52 2f 46 69 6c 74 65 72 2f ... 65486 more bytes>
proxyStream data <Buffer 25 50 44 46 2d 31 2e 34 0a 25 c3 a4 c3 bc c3 b6 c3 9f 0a 32 20 30 20 6f 62 6a 0a 3c 3c 2f 4c 65 6e 67 74 68 20 33 20 30 20 52 2f 46 69 6c 74 65 72 2f ... 65486 more bytes>
readStream data <Buffer 2f 19 bb 92 6d ff 00 9f 70 1e 0d b9 30 e5 5c 9c bc 58 7b 8b 96 e0 40 0d 07 18 fe 7a b5 15 87 b1 25 c1 ab 45 aa 89 be e6 01 c1 b3 bc e6 d5 43 a2 f3 3c ... 65486 more bytes>
proxyStream data <Buffer 2f 19 bb 92 6d ff 00 9f 70 1e 0d b9 30 e5 5c 9c bc 58 7b 8b 96 e0 40 0d 07 18 fe 7a b5 15 87 b1 25 c1 ab 45 aa 89 be e6 01 c1 b3 bc e6 d5 43 a2 f3 3c ... 65486 more bytes>
readStream data <Buffer f5 37 3a 7c 12 ed f0 49 1b dc 61 85 db 9b e1 af 75 b8 4d 87 bf d2 e1 13 3a dc aa c3 c7 75 f8 d8 47 9b 95 8f e9 f0 d1 66 f8 df 3a dc a2 c3 5f b6 c3 47 ... 40554 more bytes>
readStream end
proxyStream data <Buffer f5 37 3a 7c 12 ed f0 49 1b dc 61 85 db 9b e1 af 75 b8 4d 87 bf d2 e1 13 3a dc aa c3 c7 75 f8 d8 47 9b 95 8f e9 f0 d1 66 f8 df 3a dc a2 c3 5f b6 c3 47 ... 40554 more bytes>
writableStream data <Buffer 25 50 44 46 2d 31 2e 34 0a 25 c3 a4 c3 bc c3 b6 c3 9f 0a 32 20 30 20 6f 62 6a 0a 3c 3c 2f 4c 65 6e 67 74 68 20 33 20 30 20 52 2f 46 69 6c 74 65 72 2f ... 65486 more bytes>
proxyStream data <Buffer 25 50 44 46 2d 31 2e 34 0a 25 c3 a4 c3 bc c3 b6 c3 9f 0a 32 20 30 20 6f 62 6a 0a 3c 3c 2f 4c 65 6e 67 74 68 20 33 20 30 20 52 2f 46 69 6c 74 65 72 2f ... 65486 more bytes>
proxyStream end
writableStream data <Buffer 2f 19 bb 92 6d ff 00 9f 70 1e 0d b9 30 e5 5c 9c bc 58 7b 8b 96 e0 40 0d 07 18 fe 7a b5 15 87 b1 25 c1 ab 45 aa 89 be e6 01 c1 b3 bc e6 d5 43 a2 f3 3c ... 65486 more bytes>
error write after end
proxyStream data <Buffer 2f 19 bb 92 6d ff 00 9f 70 1e 0d b9 30 e5 5c 9c bc 58 7b 8b 96 e0 40 0d 07 18 fe 7a b5 15 87 b1 25 c1 ab 45 aa 89 be e6 01 c1 b3 bc e6 d5 43 a2 f3 3c ... 65486 more bytes>
writableStream data <Buffer f5 37 3a 7c 12 ed f0 49 1b dc 61 85 db 9b e1 af 75 b8 4d 87 bf d2 e1 13 3a dc aa c3 c7 75 f8 d8 47 9b 95 8f e9 f0 d1 66 f8 df 3a dc a2 c3 5f b6 c3 47 ... 40554 more bytes>
proxyStream data <Buffer f5 37 3a 7c 12 ed f0 49 1b dc 61 85 db 9b e1 af 75 b8 4d 87 bf d2 e1 13 3a dc aa c3 c7 75 f8 d8 47 9b 95 8f e9 f0 d1 66 f8 df 3a dc a2 c3 5f b6 c3 47 ... 40554 more bytes>
writableStream data <Buffer 25 50 44 46 2d 31 2e 34 0a 25 c3 a4 c3 bc c3 b6 c3 9f 0a 32 20 30 20 6f 62 6a 0a 3c 3c 2f 4c 65 6e 67 74 68 20 33 20 30 20 52 2f 46 69 6c 74 65 72 2f ... 65486 more bytes>
proxyStream data <Buffer 25 50 44 46 2d 31 2e 34 0a 25 c3 a4 c3 bc c3 b6 c3 9f 0a 32 20 30 20 6f 62 6a 0a 3c 3c 2f 4c 65 6e 67 74 68 20 33 20 30 20 52 2f 46 69 6c 74 65 72 2f ... 65486 more bytes>
writableStream complete
```

**Problem 2**: It can also causes infinite loops. I have only seen it once and cannot consistently reproduce. It was also seen by Heartz66  https://github.com/pkgcloud/pkgcloud/issues/667#issuecomment-508850248

My guess of what happens: the `writetableStream` listen to the event "data" of the `proxyStream`, and ends up listening to its own "data" event. And so it loops.