### PR TITLE
replacing liboneandone with liboneandone-2 with updated mocha dependency

### DIFF
--- a/lib/pkgcloud/oneandone/blockstorage/client/snapshots.js
+++ b/lib/pkgcloud/oneandone/blockstorage/client/snapshots.js
@@ -3,7 +3,7 @@
  */
 
 var Snapshot = require('../snapshot').Snapshot,
-  oneandone = require('liboneandone'),
+  oneandone = require('liboneandone-2'),
   Server = require('../../compute/server').Server;
 /**
  * client.getSnapshots

--- a/lib/pkgcloud/oneandone/client.js
+++ b/lib/pkgcloud/oneandone/client.js
@@ -5,7 +5,7 @@
  */
 
 var util = require('util'),
-  OAO = require('liboneandone'),
+  OAO = require('liboneandone-2'),
   url = 'cloudpanel-api.1and1.com/v1',
   base = require('../core/base');
 

--- a/lib/pkgcloud/oneandone/compute/client/flavors.js
+++ b/lib/pkgcloud/oneandone/compute/client/flavors.js
@@ -4,7 +4,7 @@
 
 var pkgcloud = require('../../../../../lib/pkgcloud'),
   base = require('../../../core/compute'),
-  oneandone = require('liboneandone'),
+  oneandone = require('liboneandone-2'),
   compute = pkgcloud.providers.oneandone.compute;
 
 //

--- a/lib/pkgcloud/oneandone/compute/client/images.js
+++ b/lib/pkgcloud/oneandone/compute/client/images.js
@@ -4,7 +4,7 @@
  */
 var pkgcloud = require('../../../../../lib/pkgcloud'),
   base = require('../../../core/compute'),
-  oneandone = require('liboneandone'),
+  oneandone = require('liboneandone-2'),
   compute = pkgcloud.providers.oneandone.compute;
 //
 // ### function getImages (callback)

--- a/lib/pkgcloud/oneandone/compute/client/servers.js
+++ b/lib/pkgcloud/oneandone/compute/client/servers.js
@@ -5,7 +5,7 @@
 var base = require('../../../core/compute'),
   pkgcloud = require('../../../../../lib/pkgcloud'),
   errs = require('errs'),
-  oneandone = require('liboneandone'),
+  oneandone = require('liboneandone-2'),
   compute = pkgcloud.providers.oneandone.compute;
 
 //

--- a/lib/pkgcloud/oneandone/loadbalancer/client/loadbalancers.js
+++ b/lib/pkgcloud/oneandone/loadbalancer/client/loadbalancers.js
@@ -1,7 +1,7 @@
 /**
  * Created by Ali Bazlamit on 8/31/2017.
  */
-var oneandone = require('liboneandone'),
+var oneandone = require('liboneandone-2'),
   LoadBalancer = require('../loadbalancer').LoadBalancer;
 
 //

--- a/lib/pkgcloud/oneandone/loadbalancer/client/nodes.js
+++ b/lib/pkgcloud/oneandone/loadbalancer/client/nodes.js
@@ -1,7 +1,7 @@
 /**
  * Created by Ali Bazlamit on 8/31/2017.
  */
-var oneandone = require('liboneandone'),
+var oneandone = require('liboneandone-2'),
   LoadBalancer = require('../loadbalancer').LoadBalancer,
   Node = require('../node').Node;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -518,11 +518,6 @@
         "delayed-stream": "~1.0.0"
       }
     },
-    "commander": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
-      "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM="
-    },
     "compressible": {
       "version": "2.0.17",
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.17.tgz",
@@ -685,11 +680,6 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
-    "diff": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
-      "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8="
-    },
     "dom-serializer": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
@@ -836,11 +826,6 @@
       "requires": {
         "es6-promise": "^4.0.3"
       }
-    },
-    "escape-string-regexp": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
-      "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE="
     },
     "esprima": {
       "version": "4.0.1",
@@ -1061,15 +1046,6 @@
         "assert-plus": "^1.0.0"
       }
     },
-    "glob": {
-      "version": "3.2.11",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-      "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
-      "requires": {
-        "inherits": "2",
-        "minimatch": "0.3"
-      }
-    },
     "globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
@@ -1105,11 +1081,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
       "integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg=="
-    },
-    "growl": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
-      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8="
     },
     "gtoken": {
       "version": "2.3.3",
@@ -1403,27 +1374,6 @@
         }
       }
     },
-    "jade": {
-      "version": "0.26.3",
-      "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
-      "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
-      "requires": {
-        "commander": "0.6.1",
-        "mkdirp": "0.3.0"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
-          "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY="
-        },
-        "mkdirp": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
-          "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4="
-        }
-      }
-    },
     "jmespath": {
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
@@ -1551,45 +1501,12 @@
       "integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
       "dev": true
     },
-    "liboneandone": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/liboneandone/-/liboneandone-1.2.0.tgz",
-      "integrity": "sha512-EB6Ak9qw+U4HAOnKqPtatxQ9pLclvtsBsggrvOuD4zclJ5xOeEASojsLKEC3O8KJ1Q4obE2JHhOeDuqWXvkoUQ==",
+    "liboneandone-2": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/liboneandone-2/-/liboneandone-2-1.0.0.tgz",
+      "integrity": "sha512-tILYm7wGWLlBRVtlQUrrrpui8orjhSoG8oR3cevFKbQJpjLbWFuZ4N0cUYJT/1usn3zyYMxN6JtdlmDXPY/agw==",
       "requires": {
-        "mocha": "^2.5.3",
-        "request": "^2.74.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "requires": {
-            "ms": "0.7.1"
-          }
-        },
-        "mocha": {
-          "version": "2.5.3",
-          "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
-          "integrity": "sha1-FhvlvetJZ3HrmzV0UFC2IrWu/Fg=",
-          "requires": {
-            "commander": "2.3.0",
-            "debug": "2.2.0",
-            "diff": "1.4.0",
-            "escape-string-regexp": "1.0.2",
-            "glob": "3.2.11",
-            "growl": "1.9.2",
-            "jade": "0.26.3",
-            "mkdirp": "0.5.1",
-            "supports-color": "1.2.0",
-            "to-iso-string": "0.0.2"
-          }
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
-        }
+        "request": "^2.88.0"
       }
     },
     "locate-path": {
@@ -1688,31 +1605,17 @@
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
     },
-    "minimatch": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-      "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
-      "requires": {
-        "lru-cache": "2",
-        "sigmund": "~1.0.0"
-      },
-      "dependencies": {
-        "lru-cache": {
-          "version": "2.7.3",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-          "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
-        }
-      }
-    },
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
     },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       }
@@ -3246,11 +3149,6 @@
       "integrity": "sha512-oXF8tfxx5cDk8r2kYqlkUJzZpDBqVY/II2WhvU0n9Y3XYvAYRmeaf1PvvIvTgPnv4KJ+ES5M0PyDq5Jp+Ygy2g==",
       "dev": true
     },
-    "sigmund": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
-    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -3354,11 +3252,6 @@
       "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
       "integrity": "sha1-6NK6H6nJBXAwPAMLaQD31fiavls="
     },
-    "supports-color": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
-      "integrity": "sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4="
-    },
     "teeny-request": {
       "version": "3.11.3",
       "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-3.11.3.tgz",
@@ -3382,11 +3275,6 @@
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
       "dev": true
-    },
-    "to-iso-string": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/to-iso-string/-/to-iso-string-0.0.2.tgz",
-      "integrity": "sha1-TcGeZk38y+Jb2NtQiwDG2hWCVdE="
     },
     "tough-cookie": {
       "version": "2.4.3",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "fast-json-patch": "^2.1.0",
     "filed-mimefix": "^0.1.3",
     "ip": "^1.1.5",
-    "liboneandone": "^1.2.0",
+    "liboneandone-2": "^1.0.0",
     "lodash": "^4.17.10",
     "mime": "^2.4.1",
     "qs": "^6.5.2",

--- a/test/oneandone/loadbalancer/test-loadbalancers.js
+++ b/test/oneandone/loadbalancer/test-loadbalancers.js
@@ -10,7 +10,7 @@ var should = require('should'),
   hock = require('hock'),
   http = require('http'),
   mock = !!process.env.MOCK,
-  oneandone = require('liboneandone'),
+  oneandone = require('liboneandone-2'),
   LoadBalancer = require('../../../lib/pkgcloud/oneandone/loadbalancer/loadbalancer').LoadBalancer,
   Node = require('../../../lib/pkgcloud/oneandone/loadbalancer/node').Node;
 


### PR DESCRIPTION
The [liboneandone](https://www.npmjs.com/package/liboneandone) package is no longer supported and contains an older version of [mocha](https://www.npmjs.com/package/mocha) as a dependency that has a known vulnerabilities.  

The [latest commit](https://github.com/1and1/oneandone-cloudserver-sdk-nodejs) of [liboneandone](https://www.npmjs.com/package/liboneandone) has an update for this dependency which resolves these vulnerabilities by using an updated version of [mocha](https://www.npmjs.com/package/mocha), however, [liboneandone](https://www.npmjs.com/package/liboneandone) hasn't been published to npm since July of 2018.

[liboneandone-2](https://www.npmjs.com/package/liboneandone-2) is a fork of the [liboneandone](https://www.npmjs.com/package/liboneandone) package at the [latest commit](https://github.com/1and1/oneandone-cloudserver-sdk-nodejs).

There is an [open pull request](https://github.com/pkgcloud/pkgcloud/pull/671) for [pkgcloud](https://www.npmjs.com/package/pkgcloud) which addresses this through a direct reference to the GitHub commit in [liboneandone](https://www.npmjs.com/package/liboneandone), but direct references to GitHub rather than to npm modules can cause problems for organizations with proxies.

**pkgcloud Issue References:**
- [#677 This package has a critical vulnerability by including an old version of growl, via mocha. Need to remove this dependency or upgrade dependencies in liboneandone.](https://github.com/pkgcloud/pkgcloud/issues/677)
- [#675 Liboneandone is no longer supported](https://github.com/pkgcloud/pkgcloud/issues/675)
- [#644 Update pkgcloud dependency vulnerabilities 2018-12 - `gcloud` and `liboneandone`](https://github.com/pkgcloud/pkgcloud/issues/644)

**pkgcloud Pull Request References:**
- [#671 Use libonenandone from source](https://github.com/pkgcloud/pkgcloud/pull/671)

**liboneandone Issue References:**
 - [#21 Update package.json](https://github.com/1and1/oneandone-cloudserver-sdk-nodejs/issues/21)
 - [#20 Upgrade mocha to fix security issues](https://github.com/1and1/oneandone-cloudserver-sdk-nodejs/issues/20)