### PR TITLE
update API version for Keystone

### DIFF
--- a/lib/pkgcloud/openstack/context/identity.js
+++ b/lib/pkgcloud/openstack/context/identity.js
@@ -247,6 +247,8 @@ Identity.prototype._buildAuthenticationPayload = function () {
             methods : ['password'],
             password : {
               user: {
+                name: self.options.username,
+                domain: { id: 'default' },
                 password: self.options.password
               }
             }


### PR DESCRIPTION
Update api version to 3. Change Authentication Method.
They are discontinuing v2 of the Keystone API on 24th March 2020. All users of the Keystone API must now use version 3, and make the changes required to do so.
https://storage.p19.cloud.ovh.net/v1/AUTH_47f7eb0153a7447799377451f59357ce/public/keystone-v3-request.txt