### PR TITLE
Possibility to set more s3 client options

### DIFF
--- a/lib/pkgcloud/amazon/client.js
+++ b/lib/pkgcloud/amazon/client.js
@@ -36,7 +36,7 @@ var Client = exports.Client = function (options) {
     s3ForcePathStyle: options.forcePathBucket,
     sessionToken: options.sessionToken,
     credentials: options.credentials,
-    maxTries: options.maxTries,
+    maxRetries: options.maxRetries,
     httpOptions: options.httpOptions
   };
 

--- a/lib/pkgcloud/amazon/client.js
+++ b/lib/pkgcloud/amazon/client.js
@@ -6,8 +6,8 @@
  */
 
 var util = require('util'),
-    AWS = require('aws-sdk'),
-    base = require('../core/base');
+  AWS = require('aws-sdk'),
+  base = require('../core/base');
 
 var userAgent = AWS.util.userAgent();
 var Client = exports.Client = function (options) {
@@ -18,7 +18,7 @@ var Client = exports.Client = function (options) {
   options = options || {};
 
   // Allow overriding serversUrl in child classes
-  this.provider   = 'amazon';
+  this.provider = 'amazon';
   this.endpoint = options.endpoint;
   this.securityGroup = options.securityGroup;
   this.securityGroupId = options.securityGroupId;
@@ -35,15 +35,20 @@ var Client = exports.Client = function (options) {
     region: options.region,
     s3ForcePathStyle: options.forcePathBucket,
     sessionToken: options.sessionToken,
-    credentials: options.credentials
+    credentials: options.credentials,
+    maxTries: options.maxTries,
+    httpOptions: options.httpOptions
   };
 
   // TODO think about a proxy option for pkgcloud
   // enable forwarding to mock test server
   if (options.serversUrl) {
-    this._awsConfig.httpOptions = {
-      proxy: this.protocol + options.serversUrl
-    };
+    if (!this._awsConfig.httpOptions || typeof this._awsConfig.httpOptions !== 'object') {
+      this._awsConfig.httpOptions = {};
+    }
+
+    // prioritize "serverUrl" over "httpOptions.proxy"
+    this._awsConfig.httpOptions.proxy = this.protocol + options.serversUrl;
   }
 
   if (options.endpoint) {


### PR DESCRIPTION
Allows setting 'maxRetries' and 'httpOptions' options for amazon S3.

Fixes #682