### PR TITLE
Adding support for paging in rackspace's dns records module

### DIFF
--- a/lib/pkgcloud/rackspace/dns/client/records.js
+++ b/lib/pkgcloud/rackspace/dns/client/records.js
@@ -31,10 +31,10 @@ module.exports = {
   getRecordsPaged: function (zone, page, callback) {
     var self = this,
         zoneId = zone instanceof dns.Zone ? zone.id : zone,
-        limit = page && page.limit && parseInt(page.limit) <= 100 
+        limit = page && page.limit && page.limit <= 100 
 		  ? parseInt(page.limit) 
 		  : _defaultLimitValue,
-        offset = page && page.offset && !(parseInt(page.offset) % limit) 
+        offset = page && page.offset && page.offset % limit === 0 
 		  ? parseInt(page.offset) 
 		  : _defaultOffsetValue,
         params = '?' + [[_limitParam, limit].join('='), [_offsetParam, offset].join('=')].join('&');  

--- a/lib/pkgcloud/rackspace/dns/client/records.js
+++ b/lib/pkgcloud/rackspace/dns/client/records.js
@@ -13,9 +13,52 @@ var urlJoin = require('url-join'),
     dns = pkgcloud.providers.rackspace.dns;
 
 var _urlPrefix = 'domains',
-    _recordFragment = 'records';
+    _recordFragment = 'records',
+    _defaultLimitValue = 100,
+    _defaultOffsetValue = 0,
+    _limitParam = 'limit',
+    _offsetParam = 'offset';
 
 module.exports = {
+
+  /**
+   * @name Client.getRecordsPaged
+   * @description getRecordsPaged retrieves your a list of records for this domain given the page parameters
+   * @param {Object|Number}     zone        the zone for the getRecords query
+   * @param {Object}            page        paging parameters for the getRecords query
+   * @param {Function}          callback    handles the callback of your api call
+   */
+  getRecordsPaged: function (zone, page, callback) {
+    var self = this,
+        zoneId = zone instanceof dns.Zone ? zone.id : zone,
+        limit = page && page.limit && parseInt(page.limit) <= 100 
+		  ? parseInt(page.limit) 
+		  : _defaultLimitValue,
+        offset = page && page.offset && !(parseInt(page.offset) % limit) 
+		  ? parseInt(page.offset) 
+		  : _defaultOffsetValue,
+        params = '?' + [[_limitParam, limit].join('='), [_offsetParam, offset].join('=')].join('&');  
+
+    var requestOptions = {
+      path: urlJoin(_urlPrefix, zoneId, _recordFragment, params)
+    };
+
+    self._request(requestOptions, function (err, body, res) {
+      if(err) {
+        return callback(err);
+      }
+
+      else if (!body || !body.records) {
+        return callback(new Error('Unexpected empty response'));
+      }
+
+      else{
+        return callback(null, body.records.map(function (record) {
+          return new dns.Record(self, record);
+        }), res, res.body.totalEntries);
+      }
+    });
+  },
 
   /**
    * @name Client.getRecords


### PR DESCRIPTION
Per docs a rackspace API consumer should be able to page through the records since only 100 records can be retrieved in a single request.
https://developer.rackspace.com/docs/cloud-dns/v1/api-reference/records/#search-records