### PR TITLE
With Bucket prefix support

### DIFF
--- a/lib/pkgcloud/amazon/client.js
+++ b/lib/pkgcloud/amazon/client.js
@@ -24,6 +24,7 @@ var Client = exports.Client = function (options) {
   this.securityGroupId = options.securityGroupId;
   this.version = options.version || '2014-06-15';
   this.protocol = options.protocol || 'https://';
+  this.bucketPrefix = options.bucketPrefix || '';
 
   // support either key/accessKey syntax
   this.config.key = this.config.key || options.accessKey;

--- a/lib/pkgcloud/amazon/storage/client/containers.js
+++ b/lib/pkgcloud/amazon/storage/client/containers.js
@@ -23,7 +23,13 @@ exports.getContainers = function (callback) {
       return;
     }
 
-    var containers = data.Buckets;
+    var containers = data.Buckets.filter(function(container) {
+      return container.Name.startsWith(self.bucketPrefix);
+    }).map(function(container) {
+      return Object.assign({}, container, {
+        Name: container.Name.substr(self.bucketPrefix.length)
+      })
+    });
 
     containers = containers.map(function(container) {
       return new (storage.Container)(self, container);
@@ -45,8 +51,11 @@ exports.getContainer = function (container, callback) {
     self = this;
 
   self.s3.listObjects({
-    Bucket: containerName
+    Bucket: self.bucketPrefix + containerName
   }, function(err, data) {
+    data = Object.assign({}, data, {
+      Name: data.Name.substr(self.bucketPrefix.length)
+    });
     return err
       ? callback(err)
       : callback(null, new (storage.Container)(self, data));
@@ -65,7 +74,7 @@ exports.createContainer = function (options, callback) {
     self = this;
 
   self.s3.createBucket({
-    Bucket: containerName
+    Bucket: self.bucketPrefix + containerName
   }, function(err) {
     return err
       ? callback(err)
@@ -99,7 +108,7 @@ exports.destroyContainer = function (container, callback) {
     }
 
     self.s3.deleteBucket({
-      Bucket: containerName
+      Bucket: self.bucketPrefix + containerName
     }, function (err) {
         return err
           ? callback(err)

--- a/lib/pkgcloud/amazon/storage/client/files.js
+++ b/lib/pkgcloud/amazon/storage/client/files.js
@@ -30,7 +30,7 @@ exports.removeFile = function (container, file, callback) {
   }
 
   self.s3.deleteObject({
-    Bucket: container,
+    Bucket: self.bucketPrefix + container,
     Key: file
   }, function(err, data) {
     return err
@@ -48,7 +48,7 @@ exports.upload = function (options) {
   }
 
   var s3Options = {
-    Bucket: options.container instanceof base.Container ? options.container.name : options.container,
+    Bucket: self.bucketPrefix + (options.container instanceof base.Container ? options.container.name : options.container),
     Key: options.remote instanceof base.File ? options.remote.name : options.remote
   };
 
@@ -101,6 +101,9 @@ exports.upload = function (options) {
     if (err) {
       return proxyStream.emit('error', err);
     }
+    data = Object.assign({}, data, {
+      container: data.Bucket.substr(self.bucketPrefix.length)
+    });
     return proxyStream.emit('success', new storage.File(self, data));
   });
 
@@ -113,7 +116,7 @@ exports.download = function (options) {
   var self = this;
 
   return self.s3.getObject({
-    Bucket: options.container instanceof base.Container ? options.container.name : options.container,
+    Bucket: self.bucketPrefix + (options.container instanceof base.Container ? options.container.name : options.container),
     Key: options.remote instanceof base.File ? options.remote.name : options.remote
   }).createReadStream();
 
@@ -124,7 +127,7 @@ exports.getFile = function (container, file, callback) {
       self = this;
 
   self.s3.headObject({
-    Bucket: containerName,
+    Bucket: self.bucketPrefix + containerName,
     Key: file
   }, function(err, data) {
     return err
@@ -149,7 +152,7 @@ exports.getFiles = function (container, options, callback) {
   }
 
   var s3Options = {
-    Bucket: containerName
+    Bucket: self.bucketPrefix + containerName
   };
 
   if (options.marker) {


### PR DESCRIPTION
Add bucketPrefix option for S3.

This will allows organisation to structure their bucket as following

```
org1-prod-bucket1
org1-prod-bucket2
org1-stag-bucket1
org1-stag-bucket2
```

And has identical configfor multiple env (e.g. `prod` or `stag`)